### PR TITLE
Fix: reward system and improve api

### DIFF
--- a/datura/__init__.py
+++ b/datura/__init__.py
@@ -19,7 +19,7 @@
 
 
 # version must stay on line 22
-__version__ = "0.0.180"
+__version__ = "0.0.181"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/datura/protocol.py
+++ b/datura/protocol.py
@@ -23,6 +23,9 @@ class IsAlive(Synapse):
         description="Completion status of the current StreamPrompting object. This attribute is mutable and can be updated.",
     )
 
+    def get_required_fields(self):
+        return []
+
 
 class TwitterPromptAnalysisResult(BaseModel):
     api_params: Dict[str, Any] = {}
@@ -660,6 +663,10 @@ class ScraperStreamingSynapse(StreamingSynapse):
     def deserialize(self) -> str:
         return self.completion
 
+    def get_required_fields(self) -> List[str]:
+        """Returns a list of required fields for the Twitter search query."""
+        return ["prompt"]
+
     def extract_response_json(self, response: ClientResponse) -> dict:
         headers = {
             k.decode("utf-8"): v.decode("utf-8")
@@ -819,6 +826,10 @@ class WebSearchSynapse(Synapse):
     def deserialize(self) -> str:
         return self
 
+    def get_required_fields(self) -> List[str]:
+        """Returns a list of required fields for the Twitter search query."""
+        return []
+
 
 class TwitterSearchSynapse(Synapse):
     """A class to represent Twitter Advanced Search Synapse"""
@@ -955,6 +966,10 @@ class TwitterSearchSynapse(Synapse):
     def deserialize(self) -> str:
         return self
 
+    def get_required_fields(self) -> List[str]:
+        """Returns a list of required fields for the Twitter search query."""
+        return ["query"]
+
 
 class TwitterIDSearchSynapse(Synapse):
     """A class to represent Twitter ID Advanced Search Synapse"""
@@ -987,6 +1002,10 @@ class TwitterIDSearchSynapse(Synapse):
     def deserialize(self) -> str:
         return self
 
+    def get_required_fields(self) -> List[str]:
+        """Returns a list of required fields for the Twitter search query."""
+        return ["id"]
+
 
 class TwitterURLsSearchSynapse(Synapse):
     """A class to represent Twitter URLs Advanced Search Synapse"""
@@ -1018,3 +1037,7 @@ class TwitterURLsSearchSynapse(Synapse):
 
     def deserialize(self) -> str:
         return self
+
+    def get_required_fields(self) -> List[str]:
+        """Returns a list of required fields for the Twitter search query."""
+        return ["urls"]

--- a/datura/synapse.py
+++ b/datura/synapse.py
@@ -34,19 +34,12 @@ def synapse_to_headers(self) -> dict:
         )
 
     # Getting the fields of the instance
-    instance_fields = self.model_dump()
     required = self.get_required_fields()
 
-    # Iterating over the fields of the instance
-    for field, value in instance_fields.items():
-        # If the object is not optional, serializing it, encoding it, and adding it to the headers
-
-        # Skipping the field if it's already in the headers or its value is None
-        if field in headers or value is None:
-            continue
-
-        elif required and field in required:
+    if required:
+        for field in required:
             try:
+                value = getattr(self, field)
                 # create an empty (dummy) instance of type(value) to pass pydantic validation on the axon side
                 serialized_value = json.dumps(value.__class__.__call__())
                 encoded_value = base64.b64encode(serialized_value.encode()).decode(

--- a/neurons/validators/advanced_scraper_validator.py
+++ b/neurons/validators/advanced_scraper_validator.py
@@ -482,7 +482,7 @@ class AdvancedScraperValidator(OrganicHistoryMixin):
                         len(
                             specified_uids
                             if specified_uids
-                            else self.neuron.available_uids
+                            else self.neuron.metagraph.uids
                         )
                     )
                 ]

--- a/neurons/validators/api.py
+++ b/neurons/validators/api.py
@@ -405,20 +405,22 @@ async def get_tweets_by_urls(
     if access_key != EXPECTED_ACCESS_KEY:
         raise HTTPException(status_code=401, detail="Invalid access key")
 
+    results = []
+
     try:
         urls = list(set(request.urls))
 
         bt.logging.info(f"Fetching tweets for URLs: {urls}")
 
         results = await neu.basic_scraper_validator.twitter_urls_search(urls)
-
-        if results:
-            return results
-        else:
-            raise HTTPException(status_code=404, detail="Tweets not found")
     except Exception as e:
         bt.logging.error(f"Error fetching tweets by URLs: {e}")
         raise HTTPException(status_code=500, detail=f"An error occurred: {str(e)}")
+
+    if results:
+        return results
+    else:
+        raise HTTPException(status_code=404, detail="Tweets not found")
 
 
 @app.get(

--- a/neurons/validators/base_validator.py
+++ b/neurons/validators/base_validator.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 import asyncio
+import itertools
 import torch
 import bittensor as bt
 import argparse
@@ -15,6 +16,7 @@ class AbstractNeuron(ABC):
         self.dendrite1: "bt.dendrite" = None
         self.dendrite2: "bt.dendrite" = None
         self.dendrite3: "bt.dendrite" = None
+        self.dendrites: itertools.cycle[bt.dendrite]
 
     @classmethod
     @abstractmethod

--- a/neurons/validators/basic_scraper_validator.py
+++ b/neurons/validators/basic_scraper_validator.py
@@ -408,7 +408,7 @@ class BasicScraperValidator(OrganicHistoryMixin):
                         len(
                             specified_uids
                             if specified_uids
-                            else self.neuron.available_uids
+                            else self.neuron.metagraph.uids
                         )
                     )
                 ]

--- a/neurons/validators/basic_web_scraper_validator.py
+++ b/neurons/validators/basic_web_scraper_validator.py
@@ -344,7 +344,7 @@ class BasicWebScraperValidator(OrganicHistoryMixin):
                         len(
                             specified_uids
                             if specified_uids
-                            else self.neuron.available_uids
+                            else self.neuron.metagraph.uids
                         )
                     )
                 ]

--- a/neurons/validators/validator.py
+++ b/neurons/validators/validator.py
@@ -8,6 +8,8 @@ import copy
 import bittensor as bt
 import time
 import sys
+import itertools
+
 from datura.protocol import IsAlive
 from datura.bittensor.dendrite import Dendrite
 from datura.bittensor.subtensor import Subtensor
@@ -120,6 +122,14 @@ class Neuron(AbstractNeuron):
             self.dendrite1 = bt.dendrite(wallet=self.wallet)
             self.dendrite2 = bt.dendrite(wallet=self.wallet)
             self.dendrite3 = bt.dendrite(wallet=self.wallet)
+
+        self.dendrites = itertools.cycle(
+            [
+                self.neuron.dendrite1,
+                self.neuron.dendrite2,
+                self.neuron.dendrite3,
+            ]
+        )
 
         self.uid = self.metagraph.hotkeys.index(self.wallet.hotkey.ss58_address)
         if self.wallet.hotkey.ss58_address not in self.metagraph.hotkeys:

--- a/neurons/validators/validator.py
+++ b/neurons/validators/validator.py
@@ -676,7 +676,7 @@ class Neuron(AbstractNeuron):
                             bt.logging.info(
                                 "No available UIDs, sleeping for 10 seconds."
                             )
-                            await asyncio.sleep(10)
+                            await asyncio.sleep(5)
                             continue
 
                         if random.choices([True, False], weights=[0.6, 0.4])[0]:
@@ -695,7 +695,7 @@ class Neuron(AbstractNeuron):
                 while True:
                     try:
                         if not self.available_uids:
-                            await asyncio.sleep(10)
+                            await asyncio.sleep(5)
                             continue
                         self.loop.create_task(self.run_organic_queries())
                         self.loop.create_task(self.run_basic_organic_queries())


### PR DESCRIPTION
- Fixed non-available uids getting same weight from previous in moving averaged scores, as scores were updated only for available miners.
- Fixed performance issue in Bittensor synapse `to_headers` method by manually adding `get_required_fields` in our synapses. This is more like hack, there is no other way, we cannot remove `bt` headers as it's used for request validation in miner. 
- Used multiple dendrites for organic twitter search requests to allow more aiohttp request limit
- Fixed tweet by urls endpoint returning 500 status if tweets were not found