### PR TITLE
feat: add flow items to streaming synapse protocol

### DIFF
--- a/datura/protocol.py
+++ b/datura/protocol.py
@@ -280,7 +280,8 @@ class ReportItem(BaseModel):
 class FlowItem(BaseModel):
     id: str
     type: Literal["Sources", "Description", "Queries"]
-    content: str | List[str]
+    content: Optional[str | List[str]] = None
+    status: Literal["in_progress", "finished"] = "finished"
     time: int
 
 

--- a/datura/protocol.py
+++ b/datura/protocol.py
@@ -278,6 +278,7 @@ class ReportItem(BaseModel):
 
 
 class FlowItem(BaseModel):
+    id: str
     type: Literal["Sources", "Description", "Queries"]
     content: str | List[str]
     time: int


### PR DESCRIPTION
**Example code for miners**
```
flow_item = {
   "type": "Description",
   "content: "Text description what miners are going to do",
}
```
or
```
flow_item = {
   "type": "Sources",
   // list of source links
   "content: ['https://www.python.org/', 'https://www.w3schools.com/python/python_intro.asp'],
}
```
or
```
flow_item = {
   "type": "Queries",
   // list of query text miniers are using for deep search
   "content: ['what is python', 'concepts of python'],
}
```
then
```
await send(
    {
        "type": "http.response.body",
        "body": json.dumps({"type": "flow", "content": flow_item }).encode("utf-8"),
        "more_body": True,
    }
)
```