### PR TITLE
Fix: Add timeout to SerpAPI HTTP requests

### DIFF
--- a/desearch/tools/search/serp_api_wrapper.py
+++ b/desearch/tools/search/serp_api_wrapper.py
@@ -1,4 +1,5 @@
 import aiohttp
+from aiohttp import ClientTimeout
 from typing import Any, Dict, Optional, Tuple
 
 
@@ -37,12 +38,13 @@ class SerpAPIWrapper:
             return url, params
 
         url, params = construct_url_and_params()
+        timeout = ClientTimeout(total=30)
         if not self.aiosession:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(url, params=params) as response:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.get(url, params=params, timeout=timeout) as response:
                     res = await response.json()
         else:
-            async with self.aiosession.get(url, params=params) as response:
+            async with self.aiosession.get(url, params=params, timeout=timeout) as response:
                 res = await response.json()
 
         return res


### PR DESCRIPTION
## Problem

The SerpAPI wrapper makes HTTP requests without any timeout configured. If SerpAPI is slow or unresponsive, the request hangs indefinitely, blocking the validator or miner.

## Solution

Added a 30-second timeout to both the ClientSession and individual GET requests. This prevents indefinite hanging while still allowing reasonable time for API responses.

## Why This Matters

- SerpAPI calls are in the critical path for web search functionality
- A single hanging request can freeze the entire validator/miner process
- This affects both scoring and reward computation
- Network issues or API slowdowns should not cause complete service failure