### PR TITLE
fix: initialize success and message before try block to prevent UnboundLocalError

### DIFF
--- a/neurons/validators/weights.py
+++ b/neurons/validators/weights.py
@@ -68,6 +68,8 @@ def init_wandb(self):
 async def set_weights_subtensor(
     subtensor: bt.AsyncSubtensor, wallet: bt.Wallet, netuid, uids, weights, version_key
 ):
+    success = False
+    message = ""
     try:
         success, message = await subtensor.set_weights(
             wallet=wallet,


### PR DESCRIPTION
## Summary

- `set_weights_subtensor` in `neurons/validators/weights.py` references `message` in the `except` branch, but it is only assigned inside the `try` block. Any exception raised by `subtensor.set_weights()` before it returns causes `UnboundLocalError: local variable 'message' referenced before assignment`.
- Fix: initialize `success = False` and `message = ""` before the `try` block so the except handler can always safely return them.

## Test plan

- [ ] Simulate a network error in `subtensor.set_weights()` — function should return `(False, "")` instead of crashing with `UnboundLocalError`
- [ ] Syntax validated: `python3 -c "import ast; ast.parse(open('neurons/validators/weights.py').read())"`

Closes #331