### PR TITLE
fix: guard against ZeroDivisionError when response.count is 0 in TwitterCountPenalty

### DIFF
--- a/neurons/validators/penalty/twitter_count_penalty.py
+++ b/neurons/validators/penalty/twitter_count_penalty.py
@@ -34,6 +34,10 @@ class TwitterCountPenaltyModel(BasePenaltyModel):
 
             results_count = len(response.results)
 
+            if response.count == 0:
+                penalties[index] = 0.0
+                continue
+
             if results_count > response.count:
                 penalties[index] = 0
             else:


### PR DESCRIPTION
## Summary

- `TwitterCountPenalty.calculate` in `neurons/validators/penalty/twitter_count_penalty.py` computed `1 - results_count / response.count` without checking for `response.count == 0`, causing `ZeroDivisionError`.
- Fix: add an early-continue guard that sets `penalties[index] = 0.0` and skips to the next response when `response.count == 0`.

## Test plan

- [ ] Pass a `TwitterSearchSynapse` with `count=0` — should return penalty `0.0` without raising
- [ ] Normal responses still compute the correct penalty ratio
- [ ] Syntax validated: `python3 -c "import ast; ast.parse(open('neurons/validators/penalty/twitter_count_penalty.py').read())"`

Closes #333