### PR TITLE
Update Python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ aggregated search results.
 Miners contribute search capacity and are rewarded based on result quality and volume.
 Expected setup steps:
 
-- Prepare a server with Python ≥ 3.10, PM2, and a registered hotkey on netuid 22.
+- Prepare a server with Python ≥ 3.11, PM2, and a registered hotkey on netuid 22.
 - Configure credentials for OpenAI, SerpAPI, and Apify.
 - Declare per-search-type concurrency in `neurons/miners/manifest.json`.
 - Run the axon with PM2.
@@ -76,7 +76,7 @@ See the [Miner Setup Guide](./docs/running_a_miner.md) for full instructions.
 
 Validators verify miner outputs and write weights on-chain. Expected setup steps:
 
-- Prepare a server with Python ≥ 3.10, PM2, Redis, `jq`, and a registered validator hotkey.
+- Prepare a server with Python ≥ 3.11, PM2, Redis, `jq`, and a registered validator hotkey.
 - Configure credentials for OpenAI, Apify, ScrapingDog, and W&B.
 - Generate a public API access key and run the autoupdate script.
 

--- a/docs/running_a_miner.md
+++ b/docs/running_a_miner.md
@@ -6,7 +6,7 @@ directly via dendrite.
 
 ## Prerequisites
 
-- Python ≥ 3.10
+- Python ≥ 3.11
 - [PM2](https://pm2.io/docs/runtime/guide/installation/) for process supervision
 - A registered hotkey on subnet 22 (mainnet) or 41 (testnet)
 

--- a/docs/running_a_validator.md
+++ b/docs/running_a_validator.md
@@ -12,7 +12,7 @@ A validator runs three PM2 processes (managed by `run.sh`):
 
 ## Prerequisites
 
-- Python ≥ 3.10 (recommended: conda env)
+- Python ≥ 3.11 (recommended: conda env)
 - [Redis](https://redis.io/docs/latest/operate/oss_and_stack/install/install-redis/)
 - [PM2](https://pm2.io/docs/runtime/guide/installation/)
 - `jq`, `npm` for the autoupdate loop
@@ -30,7 +30,7 @@ directory is under the repo root and gitignored.
 Create a conda env, clone the repo, install deps:
 
 ```sh
-conda create -n val python=3.10 -y
+conda create -n val python=3.11 -y
 conda activate val
 
 git clone https://github.com/Desearch-ai/subnet-22.git

--- a/neurons/validators/validator.py
+++ b/neurons/validators/validator.py
@@ -382,7 +382,7 @@ class Neuron(AbstractNeuron):
 
             await self.sync_available_uids()  # Initial sync
 
-            self.loop = asyncio.get_event_loop()
+            self.loop = asyncio.get_running_loop()
 
             init_wandb(self)
 

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     include_package_data=True,
     author_discord="p383_54249",
     license="MIT",
-    python_requires=">=3.10",
+    python_requires=">=3.11",
     install_requires=requirements,
     classifiers=[
         "Development Status :: 3 - Alpha",
@@ -81,9 +81,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Software Development",
     ],
 )


### PR DESCRIPTION
- [x] Update Python from 3.10 to min 3.11

`bt-ddos-shield` requires 3.11+ and this is prep.