### PR TITLE
Rewrite SN22 README and public docs for current repo/API/runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,100 +2,94 @@
 
 <img src="./docs/assets/desearch-logo.png" alt="Desearch" width="480" />
 
-# **Subnet 22 on Bittensor**
+# Subnet 22 (SN22) on Bittensor
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 </div>
 
-Welcome to **Desearch powered by Bittensor Subnet 22**! Desearch is a decentralized,
-AI-powered search engine that returns unbiased and verifiable results across X, Reddit,
-Arxiv, Hacker News, Wikipedia, YouTube, and the broader web. API access is available at
-[desearch.ai](https://desearch.ai).
+SN22 is the Bittensor subnet behind Desearch's decentralized real-time intelligence layer. It coordinates miners and validators that serve live web, X/Twitter, and multi-source search data for Desearch API and console products.
 
-## Table of Contents
+This repository contains the subnet runtime: miner axons, validator scoring, the validator FastAPI service, operator runbooks, and shared protocol models.
 
-- [Introduction](#introduction)
-- [Key Features](#key-features)
-- [High-Level Architecture](#high-level-architecture)
-- [Getting Started](#getting-started)
-  - [For API Consumers](#for-api-consumers)
-  - [For Miners](#for-miners)
-  - [For Validators](#for-validators)
-- [Monitoring](#monitoring)
-- [Contact and Support](#contact-and-support)
+## Architecture
 
-## Introduction
+| Component | Role | Main files |
+| --- | --- | --- |
+| Miner | Runs a Bittensor axon, declares search capacity, answers health checks, and serves AI, X/Twitter, and web search synapses. | `neurons/miners/miner.py`, `neurons/miners/config.py`, `neurons/miners/manifest.template.json` |
+| Validator | Sends synthetic and organic queries to miners, verifies results with independent providers, stores scoring windows, and writes weights on-chain. | `neurons/validators/validator_service.py`, `neurons/validators/scoring/`, `neurons/validators/reward/` |
+| Validator API | Runs FastAPI next to the validator so trusted Desearch services can request organic search and inspect public miner state. Protected routes require the `access-key` header. | `neurons/validators/api.py`, `neurons/validators/dependencies.py`, `run.sh` |
+| Shared package | Defines protocol models, synapses, tool helpers, dataset utilities, and common configuration. | `desearch/protocol.py`, `desearch/miner_config.py`, `desearch/tools/` |
 
-Desearch delivers an unbiased, verifiable search experience built on the Bittensor
-network. Miners compete to return the best search results from multiple sources;
-validators independently verify result quality and assign on-chain rewards. Through
-the public API, developers and AI builders integrate real-time, decentralized search
-into their products.
+## Setup path
 
-## Key Features
+### 1. Install the subnet package
 
-- **AI-powered analysis** — decentralized models produce relevant, contextual, unfiltered results.
-- **Diverse data sources** — X, Reddit, Arxiv, Hacker News, Wikipedia, YouTube, and general web.
-- **Sentiment and metadata analysis** — captures emotional tone and key metadata for social content.
-- **Verifiable rewards** — validators independently scrape and score miner outputs.
-- **Extensible** — community-driven improvements to scoring, sources, and relevance.
+```bash
+git clone https://github.com/Desearch-ai/subnet-22.git
+cd subnet-22
+python3 -m pip install -r requirements.txt
+python3 -m pip install -e .
+```
 
-## High-Level Architecture
+The root project is Python (`requirements.txt`, `setup.py`). `utility-api/` is a separate FastAPI service with its own `pyproject.toml`.
 
-- **Miners** run a single Bittensor **axon** that answers `IsAlive` and all search synapses
-  (AI / Twitter / Web). Validators call the axon directly via dendrite.
-- **Validators** generate synthetic queries every UTC hour, dispatch them to miners,
-  independently verify results against ground-truth scrapers (Apify, ScrapingDog), and
-  write weights on-chain. They also expose an organic-search FastAPI that the Desearch
-  product backend calls on behalf of API consumers.
-- **Bittensor network** — settles miner compensation on-chain in $TAO.
+### 2. Choose an operator role
 
-## Getting Started
+- **Miner operators** register a hotkey on netuid 22, configure `neurons/miners/.env`, create `neurons/miners/manifest.json`, and run the miner axon under PM2. See [Running a Miner](./docs/running_a_miner.md).
+- **Validator operators** register a validator hotkey on netuid 22, configure validator credentials, run `run.sh` to manage the validator service plus API, and monitor weights/scoring. See [Running a Validator](./docs/running_a_validator.md).
+- **Desearch service integrators** should use the external Desearch API/console. The validator API documented here is a subnet-facing service protected by `EXPECTED_ACCESS_KEY`, not the public billing/auth layer.
 
-### For API Consumers
+### 3. Configure environment variables
 
-To integrate Desearch into your product, sign up at
-[console.desearch.ai](https://console.desearch.ai) and generate an API key. New users
-receive $5 in free credits after adding a payment method. Consumers send requests to the
-Desearch API with their API key; the Desearch backend routes those requests to
-validators on your behalf and returns the aggregated search results.
+See [Environment Variables](./docs/env_variables.md) for shared, miner-only, and validator-only settings.
 
-### For Miners
+Common requirements:
 
-Miners contribute search capacity and are rewarded based on result quality and volume.
-Expected setup steps:
+- Shared: `OPENAI_API_KEY`, `APIFY_API_KEY`
+- Miner-only: `SERPAPI_API_KEY`, optional `TWITTER_BEARER_TOKEN`, wallet/netuid/axon settings
+- Validator-only: `EXPECTED_ACCESS_KEY`, `SCRAPINGDOG_API_KEY`, `WANDB_API_KEY`, API/service ports
 
-- Prepare a server with Python ≥ 3.10, PM2, and a registered hotkey on netuid 22.
-- Configure credentials for OpenAI, SerpAPI, and Apify.
-- Declare per-search-type concurrency in `neurons/miners/manifest.json`.
-- Run the axon with PM2.
+### 4. Validate the checkout
 
-See the [Miner Setup Guide](./docs/running_a_miner.md) for full instructions.
+```bash
+# Fast syntax/import check
+python3 -m compileall desearch neurons tests scripts
 
-### For Validators
+# Project test suite
+pytest
 
-Validators verify miner outputs and write weights on-chain. Expected setup steps:
+# Confirm the current validator link endpoints are present in source
+grep -n '"/search/links/web"\|"/search/links/twitter"\|"/search/links"' neurons/validators/api.py
 
-- Prepare a server with Python ≥ 3.10, PM2, Redis, `jq`, and a registered validator hotkey.
-- Configure credentials for OpenAI, Apify, ScrapingDog, and W&B.
-- Generate a public API access key and run the autoupdate script.
+# Runtime checks after PM2 processes are running
+pm2 status
+pm2 logs desearch_miner
+pm2 logs desearch_validator_process
+pm2 logs desearch_api_process
+```
 
-See the [Validator Setup Guide](./docs/running_a_validator.md) for full instructions.
+## Current validator API surface
 
-### Additional Guides
+The validator API is implemented in `neurons/validators/api.py` and documented in [API Reference](./docs/api.md). Key search-link routes are:
 
-- [Environment Variables](./docs/env_variables.md)
-- [Testnet Operations](./docs/running_on_testnet.md)
-- [Mainnet Operations](./docs/running_on_mainnet.md)
+- `POST /search/links/web`
+- `POST /search/links/twitter`
+- `POST /search/links`
 
-## Monitoring
+Protected routes require the `access-key` header matching `EXPECTED_ACCESS_KEY`. Public miner status routes under `/public/miners` are intentionally unauthenticated.
 
-Validators stream metrics to Weights & Biases. Public dashboards are available at
-[wandb.ai/smart-scrape/smart-scrape-1.0](https://wandb.ai/smart-scrape/smart-scrape-1.0).
+## Documentation index
 
-## Contact and Support
+- [API Reference](./docs/api.md) — validator API routes, auth, request shapes, and examples.
+- [Environment Variables](./docs/env_variables.md) — shared, miner-only, and validator-only variables.
+- [Running a Miner](./docs/running_a_miner.md) — miner install, manifest, PM2 run commands, and monitoring.
+- [Running a Validator](./docs/running_a_validator.md) — validator service/API/autoupdate processes and operational flags.
+- [Mainnet Operations](./docs/running_on_mainnet.md) — running miner or validator hotkeys on Bittensor mainnet netuid 22.
+- [Testnet Operations](./docs/running_on_testnet.md) — testnet wallet/subnet workflow.
 
-- **Website** — [desearch.ai](https://desearch.ai)
-- **Subnet 22 channel** — [Bittensor Discord](https://discord.com/channels/799672011265015819/1189589759065067580)
-- **Desearch Discord** — [Join the Desearch community server](https://discord.com/invite/eb6DTZNMF5)
+## Support
+
+- Website: [desearch.ai](https://desearch.ai)
+- Console/API product: [console.desearch.ai](https://console.desearch.ai)
+- Desearch Discord: [Join the community](https://discord.com/invite/eb6DTZNMF5)

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,140 @@
+# SN22 Validator API Reference
+
+`neurons/validators/api.py` runs a FastAPI service beside an SN22 validator. Trusted Desearch services use it to request organic subnet-backed search and to inspect public miner state observed by that validator.
+
+The default server URL in OpenAPI is `http://localhost:8005`; override the runtime port with `PORT`.
+
+## Authentication
+
+Protected routes require an `access-key` header that exactly matches the validator's `EXPECTED_ACCESS_KEY` environment variable.
+
+```bash
+-H 'access-key: <EXPECTED_ACCESS_KEY>'
+```
+
+If `EXPECTED_ACCESS_KEY` is not configured, protected routes return `403`. If the header is wrong or missing, they return `401`.
+
+Public miner status routes under `/public/miners` do not require authentication.
+
+## Request models
+
+### `SearchRequest`
+
+Used by `POST /search`.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `prompt` | string | Search prompt/query. |
+| `tools` | string[] | Tool names such as `Twitter Search`, `Web Search`, `ArXiv Search`, `Wikipedia Search`, `Youtube Search`, `Hacker News Search`, `Reddit Search`. |
+| `start_date`, `end_date` | string \| null | Optional UTC timestamps, e.g. `2025-05-01T00:00:00Z`. |
+| `date_filter` | enum \| null | Defaults to the server's past-week filter. |
+| `model` | enum \| null | Defaults to `NOVA`. |
+| `count` | integer | Per-source result count. Min `10`, max `200`; default `10`. |
+| `result_type` | enum \| null | Defaults to links plus final summary. |
+| `system_message` | string \| null | Optional summary instructions. |
+| `scoring_system_message` | string \| null | Optional scoring instructions. |
+| `chat_history` | object[] | Optional chat history items. |
+
+### `LinksSearchRequest`
+
+Used by the link-only endpoints.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `prompt` | string | Search prompt/query. |
+| `tools` | string[] | Used by `/search/links/web` and `/search/links/twitter`; `/search/links` uses the server's full tool list. |
+| `model` | enum \| null | Defaults to `NOVA`. |
+| `count` | integer | Per-source result count. Min `10`, max `200`; default `10`. |
+
+## Protected routes
+
+| Method | Route | Input | Response |
+| --- | --- | --- | --- |
+| `GET` | `/` | none | Health check: `{"status":"healthy","version":"..."}` when the validator service is reachable. |
+| `POST` | `/search` | `SearchRequest` JSON body | Server-sent event stream of search results. |
+| `POST` | `/search/links/web` | `LinksSearchRequest` JSON body | JSON object of aggregated link results for the requested tools. |
+| `POST` | `/search/links/twitter` | `LinksSearchRequest` JSON body | JSON object of aggregated X/Twitter link results for the requested tools. |
+| `POST` | `/search/links` | `LinksSearchRequest` JSON body | JSON object of aggregated link results across all server-supported tools. |
+| `POST` | `/twitter/search` | Twitter filter JSON body | List of matching tweet objects. |
+| `POST` | `/twitter/urls` | `{ "urls": ["https://x.com/.../status/..."] }` | List of tweet objects for the requested URLs, or `404` if none are found. |
+| `GET` | `/twitter/{id}` | path parameter `id` | One tweet object for the requested tweet ID, or `404` if not found. |
+| `GET` | `/web/search` | query parameters `query`, `num`, `start` | `{ "data": [...] }` web search result list. |
+
+The exact current link endpoint strings in `neurons/validators/api.py` are `/search/links/web`, `/search/links/twitter`, and `/search/links`.
+
+### Link endpoint examples
+
+```bash
+curl -s 'http://localhost:8005/search/links/web' \
+  -H 'content-type: application/json' \
+  -H 'access-key: <EXPECTED_ACCESS_KEY>' \
+  -d '{
+    "prompt": "latest Bittensor subnet news",
+    "tools": ["Web Search", "Hacker News Search"],
+    "count": 10
+  }'
+```
+
+```bash
+curl -s 'http://localhost:8005/search/links/twitter' \
+  -H 'content-type: application/json' \
+  -H 'access-key: <EXPECTED_ACCESS_KEY>' \
+  -d '{
+    "prompt": "SN22 Desearch",
+    "tools": ["Twitter Search"],
+    "count": 10
+  }'
+```
+
+```bash
+curl -s 'http://localhost:8005/search/links' \
+  -H 'content-type: application/json' \
+  -H 'access-key: <EXPECTED_ACCESS_KEY>' \
+  -d '{
+    "prompt": "decentralized search infrastructure",
+    "tools": ["Web Search"],
+    "count": 10
+  }'
+```
+
+`/search/links` currently ignores `tools` for source selection and uses the server's full `available_tools` list.
+
+### Twitter filter search
+
+`POST /twitter/search` accepts:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `query` | string | Search text. Defaults to empty string. |
+| `sort` | string | Defaults to `Top`. |
+| `user` | string \| null | Optional author filter. |
+| `start_date`, `end_date` | string \| null | Optional date filters. |
+| `lang` | string \| null | Optional language filter. |
+| `verified`, `blue_verified`, `is_quote`, `is_video`, `is_image` | boolean \| null | Optional tweet/account filters. |
+| `min_retweets`, `min_replies`, `min_likes` | integer \| null | Optional engagement thresholds. |
+| `count` | integer | Max `100`; default `20`. |
+
+### Web search
+
+```bash
+curl -s 'http://localhost:8005/web/search?query=latest%20AI%20news&num=10&start=0' \
+  -H 'access-key: <EXPECTED_ACCESS_KEY>'
+```
+
+## Public miner status routes
+
+| Method | Route | Response |
+| --- | --- | --- |
+| `GET` | `/public/miners` | Validator identity plus active miners grouped by hotkey and per-search-type state. |
+| `GET` | `/public/miners/{hotkey}` | Per-miner state plus 72-hour scoring-window history for each search type. |
+
+Public miner state is read from `MINER_DB_PATH`, which defaults to `.state/miner_state.db` under the repository root.
+
+## OpenAPI routes
+
+FastAPI also serves interactive docs and schema routes by default:
+
+- `GET /docs`
+- `GET /openapi.json`
+
+Use these locally to inspect the exact schema generated by the current code.

--- a/docs/env_variables.md
+++ b/docs/env_variables.md
@@ -1,53 +1,73 @@
 # Environment Variables
 
-Reference for every environment variable consumed by Desearch miners and validators.
-Each entry lists who needs it, what it's used for, and where to obtain it.
+Reference for environment variables consumed by SN22 miners and validators. Do not commit real secrets. Export validator settings in the operator environment; miners normally load `neurons/miners/.env` copied from `neurons/miners/.env.template`.
 
 ## Obtaining credentials
 
-- **OpenAI** — https://platform.openai.com/ (API keys)
-- **Apify** — https://apify.com/ (Actor-based scraping for Twitter/X verification)
-- **ScrapingDog** — https://www.scrapingdog.com/ (web content verification; Standard plan ~$90/mo recommended)
+- **OpenAI** — https://platform.openai.com/ (LLM scoring, summaries, and query handling)
+- **Apify** — https://apify.com/ (X/Twitter scraping and validator verification)
+- **ScrapingDog** — https://www.scrapingdog.com/ (validator web verification)
 - **SerpAPI** — https://serpapi.com/ (miner web search)
-- **Twitter API** — https://developer.twitter.com/en/portal/dashboard (miner direct tweet access)
-- **Weights & Biases** — https://wandb.ai/ (validator metrics dashboard)
+- **Twitter API** — https://developer.twitter.com/en/portal/dashboard (optional miner direct tweet access)
+- **Weights & Biases** — https://wandb.ai/ (validator metrics)
 
-## Validator variables
+## Shared variables
+
+These can be required by both miner and validator processes, depending on the role being run.
+
+| Variable | Required | Used by | Purpose |
+| --- | --- | --- | --- |
+| `OPENAI_API_KEY` | yes | miner, validator | Miner summaries/query handling; validator scoring and summary generation. |
+| `APIFY_API_KEY` | yes | miner, validator | X/Twitter scraping for miners and validator-side verification. |
+| `REDIS_HOST` | no | validator utilities | Redis host for helper clients; defaults to `localhost`. |
+| `REDIS_PORT` | no | validator utilities | Redis port for helper clients; defaults to `6379`. |
+| `CHUTES_API_TOKEN` | no | validator utilities | Optional Chutes LLM fallback for code paths that call `call_chutes`. |
+
+## Validator-only variables
 
 | Variable | Required | Purpose |
-|----------|----------|---------|
-| `OPENAI_API_KEY` | yes | LLM scoring + summary generation. |
-| `EXPECTED_ACCESS_KEY` | yes | Gates the public validator API (`neurons/validators/api.py`). Must be ≥16 chars with uppercase, lowercase, digit, and special character. Generate with `python scripts/generate_access_key.py`. |
-| `APIFY_API_KEY` | yes | Twitter/X verification via Apify actors. |
+| --- | --- | --- |
+| `EXPECTED_ACCESS_KEY` | yes for API | Gates protected validator API routes in `neurons/validators/api.py`. Must be at least 16 characters and include uppercase, lowercase, digit, and special character. Generate with `python3 scripts/generate_access_key.py`. |
 | `SCRAPINGDOG_API_KEY` | yes | Web content verification. |
-| `WANDB_API_KEY` | yes | Metrics dashboard. Run `wandb login` once after installing. |
-| `PORT` | no | Validator API port (default `8005`). |
-| `VALIDATOR_SERVICE_PORT` | no | IPC port between API and validator service (default `8006`). |
+| `WANDB_API_KEY` | yes | Metrics dashboard login. Run `wandb login` once after installing. |
+| `PORT` | no | Validator API port; default `8005`. |
+| `VALIDATOR_SERVICE_PORT` | no | IPC port between the API and validator service; default `8006`. |
+| `MINER_DB_PATH` | no | Validator miner scoring SQLite path; default `.state/miner_state.db` under the repo root. |
 
-### Example `.bashrc`
+### Validator export example
 
 ```bash
-echo 'export OPENAI_API_KEY="<key>"' >> ~/.bashrc
-echo 'export APIFY_API_KEY="<key>"' >> ~/.bashrc
-echo 'export SCRAPINGDOG_API_KEY="<key>"' >> ~/.bashrc
-echo 'export WANDB_API_KEY="<key>"' >> ~/.bashrc
-echo "export EXPECTED_ACCESS_KEY=\"$(python scripts/generate_access_key.py)\"" >> ~/.bashrc
-source ~/.bashrc
+export OPENAI_API_KEY="***"
+export APIFY_API_KEY="***"
+export SCRAPINGDOG_API_KEY="***"
+export WANDB_API_KEY="***"
+export EXPECTED_ACCESS_KEY="$(python3 scripts/generate_access_key.py)"
 ```
 
-## Miner variables
+## Miner-only variables
 
-Miners configure values via `neurons/miners/.env` (copy from `neurons/miners/.env.template`).
-CLI args passed to `pm2 start … -- …` take precedence over `.env` values.
+Miners load `neurons/miners/.env` automatically on startup. CLI args passed to `pm2 start ... -- ...` take precedence over `.env` values.
 
 | Variable | Required | Purpose |
-|----------|----------|---------|
-| `OPENAI_API_KEY` | yes | Summary/query generation inside `scraper_miner`. |
-| `SERPAPI_API_KEY` | yes | Web search (miners). |
-| `APIFY_API_KEY` | yes | Twitter/X scraping. |
-| `TWITTER_BEARER_TOKEN` | optional | Direct Twitter API access (`desearch/services/twitter_api_wrapper.py`). Not required if you rely on Apify alone. |
-| `WALLET_NAME` | no | Default wallet name for the axon (default `miner`). `--wallet.name` overrides. |
-| `WALLET_HOTKEY` | no | Default hotkey (default `default`). `--wallet.hotkey` overrides. |
-| `SUBTENSOR_NETWORK` | no | `finney` / `test` / `local` (default `finney`). `--subtensor.network` overrides. |
-| `NETUID` | no | Subnet UID (default `22`). `--netuid` overrides. |
-| `AXON_PORT` | no | Axon port (default `14000`). `--axon.port` overrides. |
+| --- | --- | --- |
+| `SERPAPI_API_KEY` | yes | Web search for miner responses. |
+| `TWITTER_BEARER_TOKEN` | optional | Direct Twitter API access in `desearch/services/twitter_api_wrapper.py`; not required if the miner relies on Apify. |
+| `WALLET_NAME` | no | Default wallet name for the axon; default `miner`. `--wallet.name` overrides. |
+| `WALLET_HOTKEY` | no | Default hotkey; default `default`. `--wallet.hotkey` overrides. |
+| `SUBTENSOR_NETWORK` | no | Chain/network selector such as `finney`, `test`, or a custom endpoint; default `finney`. `--subtensor.network` overrides. |
+| `NETUID` | no | Subnet UID; default `22`. `--netuid` overrides. |
+| `AXON_PORT` | no | Axon port; default `8098` in `neurons/miners/.env.template`. `--axon.port` overrides. |
+
+### Miner `.env` example
+
+```dotenv
+WALLET_NAME=miner
+WALLET_HOTKEY=default
+SUBTENSOR_NETWORK=finney
+NETUID=22
+AXON_PORT=8098
+OPENAI_API_KEY=***
+SERPAPI_API_KEY=***
+APIFY_API_KEY=***
+# TWITTER_BEARER_TOKEN=***
+```

--- a/docs/running_a_validator.md
+++ b/docs/running_a_validator.md
@@ -5,8 +5,8 @@ A validator runs three PM2 processes (managed by `run.sh`):
 1. `desearch_validator_process` — core neuron (`neurons/validators/validator_service.py`).
    Syncs the metagraph, generates synthetic queries, dispatches to miners via dendrite,
    scores responses, and writes weights on-chain.
-2. `desearch_api_process` — public FastAPI (`neurons/validators/api.py`) that serves organic
-   search requests to paying consumers.
+2. `desearch_api_process` — protected FastAPI (`neurons/validators/api.py`) that serves organic
+   search requests to trusted Desearch services.
 3. `desearch_autoupdate` — `run.sh` itself, which pulls new releases every 20 minutes and
    restarts the other two processes.
 
@@ -35,8 +35,8 @@ conda activate val
 
 git clone https://github.com/Desearch-ai/subnet-22.git
 cd subnet-22
-python -m pip install -r requirements.txt
-python -m pip install -e .
+python3 -m pip install -r requirements.txt
+python3 -m pip install -e .
 ```
 
 System packages (Ubuntu/Debian):
@@ -62,7 +62,7 @@ export OPENAI_API_KEY="…"
 export APIFY_API_KEY="…"
 export SCRAPINGDOG_API_KEY="…"
 export WANDB_API_KEY="…"
-export EXPECTED_ACCESS_KEY="$(python scripts/generate_access_key.py)"
+export EXPECTED_ACCESS_KEY="$(python3 scripts/generate_access_key.py)"
 ```
 
 `EXPECTED_ACCESS_KEY` gates the validator's organic-search FastAPI. The Desearch
@@ -134,7 +134,6 @@ pm2 logs desearch_api_process
 pm2 logs desearch_autoupdate
 ```
 
-Metrics are streamed to W&B at
-https://wandb.ai/smart-scrape/smart-scrape-1.0 by default.
+Metrics are streamed to the W&B entity/project configured by the validator runtime.
 
 > Allocate at least 50 GB of free disk for W&B logs.

--- a/docs/running_on_mainnet.md
+++ b/docs/running_on_mainnet.md
@@ -1,117 +1,142 @@
-# Running on the mainneting Network
-This tutorial shows how to use the bittensor mainnetwork to create a subnetwork and connect your mechanism to it. It is highly recommended that you run mainnet first before mainnet. 
-## Steps
+# Running on Bittensor Mainnet
 
-1. Clone and Install Bittensor and the Bittensor Subnet 22.
-This clones and installs the Desearch if you don't already have it (if you do, skip this step)
+SN22 runs on Bittensor mainnet (`finney`) with `netuid 22`. This guide covers the mainnet-specific wallet, registration, and launch checks for miners and validators.
+
+Use the role-specific runbooks for full process management details:
+
+- [Running a Miner](./running_a_miner.md)
+- [Running a Validator](./running_a_validator.md)
+- [Environment Variables](./env_variables.md)
+
+## 1. Install the repo
+
 ```bash
-cd .. # back out of the subtensor repo
-git clone https://github.com/Desearch-ai/subnet-22.git # Clone the Desearch repo
-cd desearch # Enter the  Desearch  repo
-python -m pip install -e . # Install the  Desearch  package
+git clone https://github.com/Desearch-ai/subnet-22.git
+cd subnet-22
+python3 -m pip install -r requirements.txt
+python3 -m pip install -e .
 ```
 
-2. Create wallets for your subnet owner, for your validator and for your miner.
-This creates local coldkey and hotkey pairs for your 3 identities. The owner will create and control the subnet and must have at least 100 mainnet net TAO on it before it can run step 3. The validator and miner will run the respective validator/miner scripts and be registered to the subnetwork created by the owner.
+## 2. Create wallets
+
+Create a coldkey/hotkey pair for the role you will run.
+
 ```bash
-# Create a coldkey for your owner wallet.
-btcli new_coldkey --wallet.name owner
+# Miner wallet
+btcli wallet new_coldkey --wallet.name miner
+btcli wallet new_hotkey --wallet.name miner --wallet.hotkey default
 
-# Create a coldkey and hotkey for your miner wallet.
-btcli new_coldkey --wallet.name miner
-btcli new_hotkey --wallet.name miner --wallet.hotkey default
-
-# Create a coldkey and hotkey for your validator wallet.
-btcli new_coldkey --wallet.name validator
-btcli new_hotkey --wallet.name validator --wallet.hotkey default
+# Validator wallet
+btcli wallet new_coldkey --wallet.name validator
+btcli wallet new_hotkey --wallet.name validator --wallet.hotkey default
 ```
 
-3. Getting the price of subnetwork creation
-Creating subnetworks on the mainnet is competitive and the cost it determined by the rate at which new network are being registered onto the chain. By default you must have at least 100 mainnet TAO on your owner wallet to create a subnetwork. However the exact amount will fluctuate based on demand. The code below shows how to get the current price of creating a subnetwork.
+If your installed `btcli` uses the older command names, run `btcli --help` and use the equivalent wallet commands for that version.
+
+## 3. Register the hotkey on SN22
+
+Register the hotkey you will run on `netuid 22` against `finney`.
+
 ```bash
-btcli get_subnet_cost --subtensor.network finney
->> Subnet burn cost: τ100.000000000
+# Miner
+btcli subnet register \
+  --netuid 22 \
+  --wallet.name miner \
+  --wallet.hotkey default \
+  --subtensor.network finney
+
+# Validator
+btcli subnet register \
+  --netuid 22 \
+  --wallet.name validator \
+  --wallet.hotkey default \
+  --subtensor.network finney
 ```
 
-4. (Optional) Getting faucet tokens
-If you dont have enough to create a subnet you can pull mainnet faucet tokens by solving periodic POW challenges. The code below shows how to get faucet tokens.
-This step may take a while to complete depending on your system. Once you have enough TAO to purchase your slot, continue to the next step.
+Check registration and wallet state:
+
 ```bash
-btcli run_faucet --wallet.name owner --subtensor.network finney
->> Balance: τ0.000000000 ➡ τ100.000000000
->> Balance: τ100.000000000 ➡ τ200.000000000
-...
+btcli wallet overview --wallet.name miner --subtensor.network finney
+btcli wallet overview --wallet.name validator --subtensor.network finney
 ```
 
-3. Purchasing a slot
-Using the TAO from the previous step you can register your subnet to the chain. This will create a new subnet on the chain and give you the owner permissions to it. The code below shows how to purchase a slot. 
-*Note: Slots cost TAO, you wont get this TAO back, it is instead recycled back into the mechanism to be later mined.*
+## 4. Configure credentials
+
+### Miner
+
 ```bash
-# Run the register subnetwork command on the locally running chain.
-btcli register_subnet --subtensor.network finney 
-# Enter the owner wallet name which gives permissions to the coldkey to later define running hyper parameters.
->> Enter wallet name (default): owner # Enter your owner wallet name
->> Enter password to unlock key: # Enter your wallet password.
->> Register subnet? [y/n]: <y/n> # Select yes (y)
->> ⠇ 📡 Registering subnet...
-✅ Registered subnetwork with netuid: 1 # Your subnet netuid will show here, save this for later.
+cp neurons/miners/.env.template neurons/miners/.env
+$EDITOR neurons/miners/.env
 ```
 
-10. Register your validator and miner keys to the networks.
-This registers your validator and miner keys to the network giving them the first 2 slots on the network.
-```bash
-# Register your miner key to the network.
-btcli register --wallet.name miner --wallet.hotkey default  --subtensor.network finney
->> Enter netuid [1] (1): # Enter netuid 1 to specify the network you just created.
->> Continue Registration?
-  hotkey:     ...
-  coldkey:    ...
-  network:    finney [y/n]: # Select yes (y)
->> ⠦ 📡 Submitting POW...
->> ✅ Registered
+Required miner secrets include `OPENAI_API_KEY`, `APIFY_API_KEY`, and `SERPAPI_API_KEY`. Set `WALLET_NAME`, `WALLET_HOTKEY`, `SUBTENSOR_NETWORK=finney`, `NETUID=22`, and `AXON_PORT` as needed.
 
-# Register your validator key to the network.
-btcli register --wallet.name validator --wallet.hotkey default --subtensor.network finney
->> Enter netuid [1] (1): # Enter netuid 1 to specify the network you just created.
->> Continue Registration?
-  hotkey:     ...
-  coldkey:    ...
-  network:    finney [y/n]: # Select yes (y)
->> ⠦ 📡 Submitting POW...
->> ✅ Registered
+Create `neurons/miners/manifest.json` from the template and declare the concurrency you can serve for each search type.
+
+### Validator
+
+Export validator secrets in the shell/session that PM2 will inherit:
+
+```bash
+export OPENAI_API_KEY="***"
+export APIFY_API_KEY="***"
+export SCRAPINGDOG_API_KEY="***"
+export WANDB_API_KEY="***"
+export EXPECTED_ACCESS_KEY="$(python3 scripts/generate_access_key.py)"
 ```
 
-11. Check that your keys have been registered.
-This returns information about your registered keys.
-```bash
-# Check that your validator key has been registered.
-btcli overview --wallet.name validator --subtensor.network finney
-Subnet: 1                                                                                                                                                                
-COLDKEY  HOTKEY   UID  ACTIVE  STAKE(τ)     RANK    TRUST  CONSENSUS  INCENTIVE  DIVIDENDS  EMISSION(ρ)   VTRUST  VPERMIT  UPDATED  AXON  HOTKEY_SS58                    
-miner    default  0      True   0.00000  0.00000  0.00000    0.00000    0.00000    0.00000            0  0.00000                14  none  5GTFrsEQfvTsh3WjiEVFeKzFTc2xcf…
-1        1        2            τ0.00000  0.00000  0.00000    0.00000    0.00000    0.00000           ρ0  0.00000                                                         
-                                                                          Wallet balance: τ0.0         
+`EXPECTED_ACCESS_KEY` protects the validator API. Share it only with trusted Desearch services that call the validator with the `access-key` header.
 
-# Check that your miner has been registered.
-btcli overview --wallet.name miner --subtensor.network finney
-Subnet: 1                                                                                                                                                                
-COLDKEY  HOTKEY   UID  ACTIVE  STAKE(τ)     RANK    TRUST  CONSENSUS  INCENTIVE  DIVIDENDS  EMISSION(ρ)   VTRUST  VPERMIT  UPDATED  AXON  HOTKEY_SS58                    
-miner    default  1      True   0.00000  0.00000  0.00000    0.00000    0.00000    0.00000            0  0.00000                14  none  5GTFrsEQfvTsh3WjiEVFeKzFTc2xcf…
-1        1        2            τ0.00000  0.00000  0.00000    0.00000    0.00000    0.00000           ρ0  0.00000                                                         
-                                                                          Wallet balance: τ0.0   
+## 5. Start the role
+
+### Miner
+
+```bash
+pm2 start neurons/miners/miner.py \
+  --interpreter /usr/bin/python3 \
+  --name desearch_miner \
+  -- \
+  --wallet.name miner \
+  --wallet.hotkey default \
+  --netuid 22 \
+  --subtensor.network finney \
+  --axon.port 8098
 ```
 
-10. Edit the default `NETUID=1` and `CHAIN_ENDPOINT=ws://127.0.0.1:9946` arguments in `desearch/__init__.py` to match your created subnetwork.
-Or run the miner and validator directly with the netuid and chain_endpoint arguments.
-```bash
-# Run the miner with the netuid and chain_endpoint arguments.
-python neurons/miner.py --netuid 1 --subtensor.network finney --wallet.name miner --wallet.hotkey default
->> 2023-08-08 16:58:11.223 |       INFO       | Running miner for subnet: 1 on network: ws://127.0.0.1:9946 with config: ...
+### Validator
 
-# Run the validator with the netuid and chain_endpoint arguments.
-python neurons/validator.py --netuid 1 --subtensor.network finney --wallet.name validator --wallet.hotkey default
->> 2023-08-08 16:58:11.223 |       INFO       | Running validator for subnet: 1 on network: ws://127.0.0.1:9946 with config: ...
+```bash
+pm2 start run.sh --name desearch_autoupdate -- \
+  --wallet.name validator \
+  --wallet.hotkey default \
+  --netuid 22 \
+  --subtensor.network finney
 ```
 
-7. Stopping Your Nodes:
-If you want to stop your nodes, you can do so by pressing CTRL + C in the terminal where the nodes are running.
+`run.sh` manages `desearch_validator_process` and `desearch_api_process` for the validator.
+
+## 6. Validate runtime health
+
+```bash
+pm2 status
+pm2 logs desearch_miner
+pm2 logs desearch_validator_process
+pm2 logs desearch_api_process
+```
+
+Check the validator API locally when it is running:
+
+```bash
+curl -s 'http://localhost:8005/' -H 'access-key: <EXPECTED_ACCESS_KEY>'
+curl -s 'http://localhost:8005/public/miners'
+```
+
+## 7. Development validation commands
+
+Run these from the repo root before submitting changes:
+
+```bash
+python3 -m compileall desearch neurons tests scripts
+pytest
+grep -n '"/search/links/web"\|"/search/links/twitter"\|"/search/links"' neurons/validators/api.py
+```


### PR DESCRIPTION
Files changed: README.md refreshed SN22 identity, miner/validator/API roles, setup path, docs index, validation commands, and current link endpoints; docs/api.md added validator API reference from neurons/validators/api.py including /search/links/web, /search/links/twitter, /search/links plus protected/public routes; docs/env_variables.md reorganized shared, validator-only, and miner-only variables with safe export examples; docs/running_a_validator.md cleaned validator API wording, python3 examples, and stale W&B copy; docs/running_on_mainnet.md rewrote mainnet runbook for finney netuid 22 miner/validator setup. Tests added/modified: none, docs-only change. Verification: python3 -m compileall desearch neurons tests scripts passed; grep for stale strings Smart Scrape, smart-scrape, api.smartscrape.ai, Datura-ai/desearch, cddDesearch, SERPAPI_API_KEY<, mainneting returned no hits in README.md docs; source grep confirmed endpoints at neurons/validators/api.py lines 360, 372, 384; docs/api.md and README.md contain required endpoint strings; targeted pytest command with uv requirements and dummy env for tests/validators/test_api.py tests/validators/test_capacity.py tests/validators/test_query_scheduler.py passed 19 passed; full pytest command with uv requirements and dummy env collected 67 tests and failed 27 / passed 40 due existing network/auth-dependent miner/reward/logging/weights tests, not from docs changes. Commit created: 740442c docs(#1403): refresh SN22 public docs. Noteworthy: docs/api.md was newly tracked; stale brief items were already absent after cleanup and confirmed by grep; no push or PR creation run because dispatcher owns that step.

---
Task: #1403 — Rewrite SN22 README and public docs for current repo/API/runtime
Opened automatically by mission-control dispatcher.