### PR TITLE
O-80: Fix SN22 residual identity and pytest collection gaps

### DIFF
--- a/desearch/__init__.py
+++ b/desearch/__init__.py
@@ -40,5 +40,5 @@ BLACKLISTED_KEYS = [
     "5GsL9zNp1CdKmKSYBGjeF9kGReRpS8KdQv2yJ3mHVwKq2YCq",
 ]
 
-ENTITY = "smart-scrape"
-PROJECT_NAME = "smart-scrape-1.0"
+ENTITY = "desearch"
+PROJECT_NAME = "subnet-22"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools>=77", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "desearch"
+description = "Decentralized AI Search"
+requires-python = ">=3.10"
+authors = [{ name = "Desearch AI" }]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Software Development",
+]
+dynamic = ["version", "readme", "dependencies", "license"]
+
+[project.urls]
+Homepage = "https://github.com/Desearch-ai/subnet-22"
+
+[tool.setuptools.dynamic]
+version = { attr = "desearch.__version__" }
+readme = { file = ["README.md"], content-type = "text/markdown" }
+dependencies = { file = ["requirements.txt"] }
+
+[tool.setuptools.packages.find]
+where = ["."]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+    "fastapi>=0.110",
+    "httpx>=0.27",
+]

--- a/tests/test_import_contract.py
+++ b/tests/test_import_contract.py
@@ -30,3 +30,10 @@ def test_setup_package_discovery_includes_neurons_subpackages():
     assert "neurons.miners" in packages
     assert "neurons.validators" in packages
     assert "neurons.validators.apify" in packages
+
+
+def test_desearch_package_identity_uses_current_sn22_branding():
+    import desearch
+
+    assert desearch.ENTITY == "desearch"
+    assert desearch.PROJECT_NAME == "subnet-22"


### PR DESCRIPTION
## Problem
Task #1564 addresses the remaining O-80 SN22 hygiene gap: stale smart-scrape package identity in `desearch/__init__.py`, plus missing uv-consumable project/dev dependency metadata needed for `uv run python -m pytest --collect-only -q` to work from a clean task worktree. It keeps work on the task branch for the Objective branch path; nothing was pushed, merged, or targeted directly at main.

## Root cause
`desearch/__init__.py:43-44` still carried the previous `smart-scrape` / `smart-scrape-1.0` identity even though this repo is now the Desearch SN22 subnet. The repo also had `requirements.txt`, `setup.py`, and `pytest.ini`, but no `pyproject.toml` metadata for uv to install the package dependencies plus pytest/dev collection dependencies when running the exact clean-checkout command without manual `--with pytest` flags.

## Fix
- `desearch/__init__.py`: changed `ENTITY` to `desearch` and `PROJECT_NAME` to `subnet-22`.
- `pyproject.toml`: added setuptools build metadata, project metadata, dynamic version/readme/dependencies sourced from existing package files, package discovery, and a uv dev dependency group containing pytest collection/runtime helpers (`pytest`, `pytest-asyncio`, `fastapi`, `httpx`). I did not commit the generated `uv.lock`; the project already treats `requirements.txt` as the dependency source of truth and uv can resolve from the committed pyproject.
- `tests/test_import_contract.py`: added `test_desearch_package_identity_uses_current_sn22_branding`, which verifies the current SN22 identity contract and would have failed before the identity fix.

## Validation
Passed:
- `uv run python -m pytest --collect-only -q` from a cleaned worktree with no `.venv`/`uv.lock`: passed, `71 tests collected`.
- `uv run python -m pytest tests/test_import_contract.py -q`: passed, `4 passed`.
- `uv build`: passed, built `dist/desearch-0.0.209.tar.gz` and `dist/desearch-0.0.209-py3-none-any.whl`.
- `git grep -nEi 'smart[ -]?scrape|smartscrape' -- README.md docs setup.py desearch tests`: returned no hits.
- `git grep -nF -e /search/links/web -e /search/links/twitter -e /search/links -- README.md docs/api.md neurons/validators/api.py`: confirmed all required endpoint strings remain present in README, docs/api.md, and `neurons/validators/api.py`.
- Direct inspection confirmed `desearch/__init__.py:43-44` now contains `ENTITY = "desearch"` and `PROJECT_NAME = "subnet-22"`.
- Commit created: `19808f9 fix(#1564): clean SN22 identity and uv pytest collection`.

Additional non-blocking check:
- `uv run python -m pytest -q` currently fails outside this task scope (`27 failed, 44 passed`) due pre-existing suite issues that are unrelated to collection metadata: tests requiring absent live API credentials (`APIFY_API_KEY`, `SCRAPINGDOG_API_KEY`, `OPENAI_API_KEY`), stale validator module patch paths, reward model constructor drift, and a Bittensor mock signature mismatch. The required collection/import checks pass without those secrets.

## Known gaps/blockers
No blockers for the #1564 QA criteria. The full test-suite failures listed above remain adjacent pre-existing cleanup work and were not broadened into this scoped identity/collection fix.

## Production expectation
After this PR is merged into `objective/o-80-clean-sn22-objective-branch-remediation`, the SN22 package identity should no longer expose stale smart-scrape branding, and reviewers/operators should be able to run the exact uv pytest collection command from a clean checkout without manually injecting pytest dependencies. This PR is intentionally Objective-branch work only; main promotion still requires the later O-80 review and explicit Giga approval.

---
Task: #1564 — O-80: Fix SN22 residual identity and pytest collection gaps
Opened automatically by mission-control dispatcher.