### PR TITLE
feat: filter /logs/scoring by validator_uid

### DIFF
--- a/utility-api/app/domains/logs/router.py
+++ b/utility-api/app/domains/logs/router.py
@@ -236,6 +236,7 @@ async def _load_scoring_logs(
     miner_uids: list[int] | None,
     query: str | None,
     miner_coldkey: str | None = None,
+    validator_uid: int | None = None,
 ) -> list[MinerResponseLog]:
     normalized_query = _normalize_optional_query(query)
     filters = [
@@ -251,6 +252,9 @@ async def _load_scoring_logs(
 
     if miner_coldkey is not None:
         filters.append(MinerResponseLog.miner_coldkey == miner_coldkey)
+
+    if validator_uid is not None:
+        filters.append(MinerResponseLog.validator_uid == validator_uid)
 
     if normalized_query is not None:
         filters.append(MinerResponseLog.request_query.ilike(f"%{normalized_query}%"))
@@ -327,6 +331,10 @@ async def get_scoring_logs(
         None,
         description="Optional miner coldkey to filter by.",
     ),
+    validator_uid: int | None = Query(
+        None,
+        description="Optional validator UID to filter by.",
+    ),
     session: AsyncSession = Depends(get_session),
 ):
     logs = await _load_scoring_logs(
@@ -336,6 +344,7 @@ async def get_scoring_logs(
         miner_uids=miner_uids,
         query=query,
         miner_coldkey=miner_coldkey,
+        validator_uid=validator_uid,
     )
 
     return GetScoringLogsResponse(groups=_build_scoring_groups(logs))

--- a/utility-api/tests/test_logs_router.py
+++ b/utility-api/tests/test_logs_router.py
@@ -31,6 +31,9 @@ class FakeSelectResult:
     def scalars(self):
         return FakeScalarResult(self._rows)
 
+    def all(self):
+        return self._rows
+
 
 def create_test_app():
     app = FastAPI()
@@ -263,3 +266,39 @@ def test_get_scoring_logs_without_miner_uid_returns_all_miners_for_hour():
     payload = response.json()
     assert len(payload["groups"]) == 2
     assert [group["miner_uid"] for group in payload["groups"]] == [11, 12]
+
+
+def test_get_scoring_logs_filters_by_validator_uid():
+    app = create_test_app()
+    session = AsyncMock()
+    session.execute.return_value = FakeSelectResult(
+        [
+            build_log_row(
+                validator_uid=3,
+                validator_hotkey="validator-3",
+                total_reward=0.4,
+            ),
+        ]
+    )
+
+    async def override_session():
+        yield session
+
+    app.dependency_overrides[get_session] = override_session
+
+    client = TestClient(app)
+
+    response = client.get(
+        "/logs/scoring",
+        params={"search_type": "x_search", "miner_uids": 11, "validator_uid": 3},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload["groups"]) == 1
+    group = payload["groups"][0]
+    assert [log["validator_uid"] for log in group["logs"]] == [3]
+
+    final_stmt = session.execute.await_args_list[-1].args[0]
+    compiled = str(final_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "validator_uid = 3" in compiled


### PR DESCRIPTION
## Summary
- Adds `validator_uid: int | None` query param to `GET /logs/scoring` so the dashboard can scope grouped scoring logs to a single validator.
- Filter is applied to both the group-key prefetch and the final select, so groups where the validator did not participate are dropped.
- Includes a test that asserts the compiled SQL contains the `validator_uid` constraint.

## Test plan
- [x] `pytest tests/test_logs_router.py::test_get_scoring_logs_filters_by_validator_uid` (passes; pre-existing failures on develop are unrelated — missing required `search_type` param on those tests).
- [ ] Smoke-check on staging once deployed: hit `/logs/scoring?search_type=ai_search&validator_uid=58` and confirm only validator 58 logs come back.