### PR TITLE
Stronger web search scoring and reworked reward weighting

### DIFF
--- a/desearch/__init__.py
+++ b/desearch/__init__.py
@@ -19,7 +19,7 @@
 
 
 # version must stay on line 22
-__version__ = "0.0.214"
+__version__ = "0.0.215"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/neurons/validators/reward/web_basic_search_content_relevance.py
+++ b/neurons/validators/reward/web_basic_search_content_relevance.py
@@ -15,11 +15,23 @@ from neurons.validators.apify.scrapingdog_scraper import (
 from neurons.validators.base_validator import AbstractNeuron
 from neurons.validators.reward.reward_llm import RewardLLM
 from neurons.validators.utils.prompts import WebSearchRelevancePrompt
+from neurons.validators.utils.web_query_operators import parse_web_query
 
 from .config import RewardModelType
 from .reward import BaseRewardEvent, BaseRewardModel, log_reward_aggregates
 
 WEB_LINK_SCRAPE_AMOUNT = 1
+
+MIN_SNIPPET_CHARS = 40
+MIN_SNIPPET_DISTINCT_TOKENS = 5
+SNIPPET_BIGRAM_THRESHOLD = 0.5
+
+_TOKEN_RE = re.compile(r"\w+")
+_STOPWORDS = frozenset(
+    "a an and are as at be but by for from has have how in is it its more most of on "
+    "or that the these this those to was were what when where which who will with you "
+    "your we our they i".split()
+)
 
 
 class WebBasicSearchContentRelevanceModel(BaseRewardModel):
@@ -42,6 +54,50 @@ class WebBasicSearchContentRelevanceModel(BaseRewardModel):
             r"\s+", " ", content.replace("\n", " ").replace("\r", " ").strip()
         )
         return html.unescape(normalized_content).lower()
+
+    @staticmethod
+    def _tokens(text: str) -> List[str]:
+        return _TOKEN_RE.findall(text.lower()) if text else []
+
+    @classmethod
+    def _is_substantive_snippet(cls, snippet: str) -> bool:
+        if not snippet or len(snippet.strip()) < MIN_SNIPPET_CHARS:
+            return False
+        distinct_content = {t for t in cls._tokens(snippet) if t not in _STOPWORDS}
+        return len(distinct_content) >= MIN_SNIPPET_DISTINCT_TOKENS
+
+    def _snippet_bigram_overlap(
+        self, snippet: str, validator_item: WebSearchValidatorResult
+    ) -> float:
+        tokens = self._tokens(self.normalize_html_content(snippet))
+        snippet_bigrams = set(zip(tokens, tokens[1:]))
+        if not snippet_bigrams:
+            return 0.0
+
+        best = 0.0
+        for target in (
+            validator_item.html_content,
+            validator_item.html_text,
+            validator_item.snippet,
+        ):
+            target_tokens = self._tokens(self.normalize_html_content(target))
+            target_bigrams = set(zip(target_tokens, target_tokens[1:]))
+            if not target_bigrams:
+                continue
+            overlap = sum(1 for b in snippet_bigrams if b in target_bigrams) / len(
+                snippet_bigrams
+            )
+            best = max(best, overlap)
+        return best
+
+    def _snippet_verified(
+        self, snippet: str, validator_item: WebSearchValidatorResult
+    ) -> bool:
+        return (
+            self._is_substantive_snippet(snippet)
+            and self._snippet_bigram_overlap(snippet, validator_item)
+            >= SNIPPET_BIGRAM_THRESHOLD
+        )
 
     async def scrape_links(self, urls):
         (
@@ -126,6 +182,7 @@ class WebBasicSearchContentRelevanceModel(BaseRewardModel):
             return {}
 
         scoring_prompt = WebSearchRelevancePrompt()
+        query_text = parse_web_query(response.query).text or response.query
         scoring_messages = []
 
         for validator_link in response.validator_links:
@@ -139,7 +196,7 @@ class WebBasicSearchContentRelevanceModel(BaseRewardModel):
                         },
                         {
                             "role": "user",
-                            "content": scoring_prompt.text(response.query, content),
+                            "content": scoring_prompt.text(query_text, content),
                         },
                     ]
                 }
@@ -171,6 +228,7 @@ class WebBasicSearchContentRelevanceModel(BaseRewardModel):
         try:
             miner_results = response.results
             validator_links = response.validator_links
+            operators = parse_web_query(response.query)
 
             miner_map = {}
 
@@ -194,6 +252,10 @@ class WebBasicSearchContentRelevanceModel(BaseRewardModel):
                     scores.append(0)
                     continue
 
+                if not operators.host_allowed(validator_item.link):
+                    scores.append(0)
+                    continue
+
                 if not self.check_title(miner_item.get("title"), validator_item.title):
                     scores.append(0)
                     continue
@@ -202,12 +264,8 @@ class WebBasicSearchContentRelevanceModel(BaseRewardModel):
                     scores.append(0)
                     continue
 
-                if not all(
-                    text.strip()
-                    in self.normalize_html_content(validator_item.html_content)
-                    or text.strip()
-                    in self.normalize_html_content(validator_item.html_text)
-                    for text in re.split(r"[.·]", miner_item.get("snippet").lower())
+                if not self._snippet_verified(
+                    miner_item.get("snippet"), validator_item
                 ):
                     scores.append(0)
                     continue

--- a/neurons/validators/reward/web_basic_search_content_relevance.py
+++ b/neurons/validators/reward/web_basic_search_content_relevance.py
@@ -13,6 +13,8 @@ from neurons.validators.apify.scrapingdog_scraper import (
     scrape_links_with_retries,
 )
 from neurons.validators.base_validator import AbstractNeuron
+from neurons.validators.reward.reward_llm import RewardLLM
+from neurons.validators.utils.prompts import WebSearchRelevancePrompt
 
 from .config import RewardModelType
 from .reward import BaseRewardEvent, BaseRewardModel, log_reward_aggregates
@@ -25,9 +27,12 @@ class WebBasicSearchContentRelevanceModel(BaseRewardModel):
     def name(self) -> str:
         return RewardModelType.web_basic_search_content_relevance.value
 
-    def __init__(self, scoring_type: None, neuron: AbstractNeuron):
+    def __init__(
+        self, scoring_type: None, neuron: AbstractNeuron, llm_reward: RewardLLM
+    ):
         super().__init__(neuron)
         self.scoring_type = scoring_type
+        self.reward_llm = llm_reward
 
     def normalize_html_content(self, content: str) -> str:
         if content is None:
@@ -116,6 +121,32 @@ class WebBasicSearchContentRelevanceModel(BaseRewardModel):
 
         return default_val_score_responses
 
+    async def llm_process_validator_links(self, response: WebSearchSynapse):
+        if not response.validator_links:
+            return {}
+
+        scoring_prompt = WebSearchRelevancePrompt()
+        scoring_messages = []
+
+        for validator_link in response.validator_links:
+            content = f"Title: {validator_link.title or ''}, Description: {validator_link.snippet or ''}"
+            scoring_messages.append(
+                {
+                    validator_link.link: [
+                        {
+                            "role": "system",
+                            "content": scoring_prompt.get_system_message(),
+                        },
+                        {
+                            "role": "user",
+                            "content": scoring_prompt.text(response.query, content),
+                        },
+                    ]
+                }
+            )
+
+        return await self.reward_llm.llm_processing(scoring_messages)
+
     @staticmethod
     def _normalize_title_for_match(title: str) -> str:
         if not title:
@@ -134,7 +165,9 @@ class WebBasicSearchContentRelevanceModel(BaseRewardModel):
 
         return miner_norm in validator_norm or validator_norm in miner_norm
 
-    def check_response_random_link(self, response: WebSearchSynapse) -> float:
+    def check_response_random_link(
+        self, response: WebSearchSynapse, relevance_scores: Dict[str, float]
+    ) -> float:
         try:
             miner_results = response.results
             validator_links = response.validator_links
@@ -179,17 +212,12 @@ class WebBasicSearchContentRelevanceModel(BaseRewardModel):
                     scores.append(0)
                     continue
 
-                query_words = response.query.strip().lower().split(" ")
+                relevance = relevance_scores.get(validator_item.link)
 
-                texts = [validator_item.title.lower(), validator_item.snippet.lower()]
-
-                if response.query and not any(
-                    word in text for word in query_words for text in texts
-                ):
-                    scores.append(0)
+                if relevance is None:
                     continue
 
-                scores.append(1)
+                scores.append(relevance)
 
             return sum(scores) / len(scores) if scores else 0.0
         except Exception as e:
@@ -200,16 +228,33 @@ class WebBasicSearchContentRelevanceModel(BaseRewardModel):
         self, responses: List[WebSearchSynapse], uids: List[int]
     ) -> Tuple[List[BaseRewardEvent], Dict[int, float]]:
         try:
-            # Step 1: fetch and fill validator_links
-            _ = await self.process_links(responses=responses)
+            await self.process_links(responses=responses)
+
+            val_score_responses_list = await self.process_response_items_in_batches(
+                responses=responses,
+                batch_size=20,
+                process_function=self.llm_process_validator_links,
+            )
+
+            scoring_prompt = WebSearchRelevancePrompt()
 
             reward_events = []
             grouped_val_score_responses = {}
 
-            for response, uid_tensor in zip(responses, uids):
+            for response, val_score_responses, uid_tensor in zip(
+                responses, val_score_responses_list, uids
+            ):
                 uid = uid_tensor.item() if hasattr(uid_tensor, "item") else uid_tensor
 
-                final_score = self.check_response_random_link(response)
+                relevance_scores = {
+                    url: scoring_prompt.extract_score(text)
+                    for url, text in (val_score_responses or {}).items()
+                    if text
+                }
+
+                final_score = self.check_response_random_link(
+                    response, relevance_scores
+                )
 
                 reward_event = BaseRewardEvent()
                 reward_event.reward = final_score

--- a/neurons/validators/scoring/capacity.py
+++ b/neurons/validators/scoring/capacity.py
@@ -1,11 +1,4 @@
-"""
-Per-UID verified-concurrency ramping.
-
-Each miner's ``verified`` grows ``RAMP_FRACTION`` of declared per scoring
-window when quality EMA stays at or above ``QUALITY_THRESHOLD``, and decays
-the same step when it falls below. ``verified`` is the synthetic allocation
-for the next epoch — bounded by ``declared`` and ``HARD_CAP_PER_UID``.
-"""
+"""Per-UID verified-concurrency ramping gated on serving all 3 search types."""
 
 from datetime import datetime, timedelta, timezone
 from typing import Optional, Protocol
@@ -15,13 +8,17 @@ import bittensor as bt
 from desearch.miner_config import SEARCH_TYPES
 from neurons.validators.scoring import miner_db
 
-QUALITY_EMA_ALPHA = 0.3
+QUALITY_EMA_ALPHA = 0.5
 
 DEFAULT_PER_UID = 1
 HARD_CAP_PER_UID = 100
-QUALITY_THRESHOLD = 0.35
+QUALITY_THRESHOLDS: dict[str, float] = {
+    "ai_search": 0.45,
+    "x_search": 0.60,
+    "web_search": 0.60,
+}
 RAMP_FRACTION = 0.10
-DECAY_FRACTION = 0.20
+DECAY_FRACTION = 0.10
 
 UNREACHABLE_FAILURE_THRESHOLD = 1
 UNREACHABLE_DECAY_FACTOR = 0.9
@@ -43,28 +40,39 @@ def set_router(router: _RouterKillSwitch) -> None:
     _router = router
 
 
-def next_verified(current: int, declared: int, quality_avg: float) -> int:
-    """Ramp by ``RAMP_FRACTION``, decay by ``DECAY_FRACTION`` (faster exit than entry)."""
+def next_verified(current: int, declared: int, all_pass: bool) -> int:
     declared = max(declared, DEFAULT_PER_UID)
-    if quality_avg >= QUALITY_THRESHOLD:
+    if all_pass:
         step = max(1, int(declared * RAMP_FRACTION))
         return min(current + step, declared, HARD_CAP_PER_UID)
     step = max(1, int(declared * DECAY_FRACTION))
     return max(DEFAULT_PER_UID, current - step)
 
 
-async def update_after_scoring(
+def passes_combined_gate(
+    ema_by_type: dict[str, float],
+    declared_by_type: dict[str, int],
+) -> bool:
+    for t, thr in QUALITY_THRESHOLDS.items():
+        if declared_by_type.get(t, 0) <= 0:
+            return False
+        if ema_by_type.get(t, 0.0) < thr:
+            return False
+    return True
+
+
+async def record_window_quality(
     uid: int,
     search_type: str,
     quality: float,
     window_start: str,
     allocated: int,
 ) -> None:
-    """Update quality EMA and ramp ``verified`` for one scoring window."""
+    """Update EMA and log the window. Ramping deferred to ``ramp_after_epoch``."""
     row = await miner_db.get_concurrency_row(uid, search_type)
     if row is None:
         bt.logging.warning(
-            f"[Capacity] update_after_scoring skipped — no row for "
+            f"[Capacity] record_window_quality skipped — no row for "
             f"uid={uid} {search_type} (miner never registered?)"
         )
         return
@@ -73,8 +81,6 @@ async def update_after_scoring(
         "quality_avg"
     ] + QUALITY_EMA_ALPHA * quality
 
-    new_verified = next_verified(row["verified"], row["declared"], quality_avg)
-
     await miner_db.insert_window(
         uid=uid,
         search_type=search_type,
@@ -82,7 +88,7 @@ async def update_after_scoring(
         hotkey=row["hotkey"],
         coldkey=row["coldkey"],
         quality_score=quality,
-        passed=quality >= QUALITY_THRESHOLD,
+        passed=quality_avg >= QUALITY_THRESHOLDS[search_type],
         verified_concurrency=allocated,
     )
 
@@ -91,7 +97,39 @@ async def update_after_scoring(
         search_type=search_type,
         quality_avg=quality_avg,
     )
-    await miner_db.bulk_update_verified(search_type, {uid: new_verified})
+
+
+async def ramp_after_epoch(uids: list[int]) -> None:
+    """Evaluate the combined gate per UID and persist verified across all 3 types."""
+    if not uids:
+        return
+
+    state = await miner_db.get_quality_state_bulk(uids)
+    if not state:
+        return
+
+    updates_by_type: dict[str, dict[int, int]] = {t: {} for t in QUALITY_THRESHOLDS}
+    pass_count = 0
+
+    for uid, by_type in state.items():
+        ema = {t: row["quality_avg"] for t, row in by_type.items()}
+        declared = {t: row["declared"] for t, row in by_type.items()}
+        all_pass = passes_combined_gate(ema, declared)
+        if all_pass:
+            pass_count += 1
+
+        for t, row in by_type.items():
+            new_v = next_verified(row["verified"], row["declared"], all_pass)
+            if new_v != row["verified"]:
+                updates_by_type[t][uid] = new_v
+
+    for t, updates in updates_by_type.items():
+        if updates:
+            await miner_db.bulk_update_verified(t, updates)
+
+    bt.logging.info(
+        f"[Capacity] ramp_after_epoch: gate passed for {pass_count}/{len(state)} UIDs"
+    )
 
 
 async def note_call_result(uid: int, search_type: str, success: bool) -> None:

--- a/neurons/validators/scoring/capacity.py
+++ b/neurons/validators/scoring/capacity.py
@@ -13,7 +13,7 @@ QUALITY_EMA_ALPHA = 0.5
 DEFAULT_PER_UID = 1
 HARD_CAP_PER_UID = 100
 QUALITY_THRESHOLDS: dict[str, float] = {
-    "ai_search": 0.45,
+    "ai_search": 0.50,
     "x_search": 0.60,
     "web_search": 0.60,
 }

--- a/neurons/validators/scoring/miner_db.py
+++ b/neurons/validators/scoring/miner_db.py
@@ -229,6 +229,32 @@ async def get_all_concurrency_data(
         }
 
 
+async def get_quality_state_bulk(
+    uids: list[int],
+) -> dict[int, dict[str, dict]]:
+    """``{uid: {search_type: {verified, declared, quality_avg}}}`` in one query."""
+    if not uids:
+        return {}
+    placeholders = ",".join("?" * len(uids))
+    async with _conn() as db:
+        cursor = await db.execute(
+            f"""
+            SELECT uid, search_type, verified, declared, quality_avg
+            FROM miner_concurrency
+            WHERE uid IN ({placeholders})
+            """,
+            tuple(uids),
+        )
+        result: dict[int, dict[str, dict]] = {}
+        async for row in cursor:
+            result.setdefault(row["uid"], {})[row["search_type"]] = {
+                "verified": row["verified"],
+                "declared": row["declared"],
+                "quality_avg": row["quality_avg"],
+            }
+        return result
+
+
 async def get_concurrency_row(uid: int, search_type: str) -> Optional[dict]:
     async with _conn() as db:
         cursor = await db.execute(

--- a/neurons/validators/scoring/query_scheduler.py
+++ b/neurons/validators/scoring/query_scheduler.py
@@ -13,9 +13,9 @@ from neurons.validators.scoring.scoring_store import SEARCH_TYPES, ScoringStore
 from neurons.validators.scoring.synthetic_query_generator import SyntheticQueryGenerator
 
 SEARCH_TYPE_WEIGHTS = {
-    "ai_search": 0.60,
-    "x_search": 0.20,
-    "web_search": 0.20,
+    "ai_search": 0.80,
+    "x_search": 0.10,
+    "web_search": 0.10,
 }
 
 ORGANIC_VALUE_MULTIPLIER = 3
@@ -63,12 +63,10 @@ def combine_superlinear_scores(
         for t, (q, v) in qv.items():
             if served[t] == 0.0:
                 continue
-            thr = capacity.QUALITY_THRESHOLDS[t]
-            q_eff = (q - thr) / (1.0 - thr)
             per_type_sum += (
                 SEARCH_TYPE_WEIGHTS[t]
                 * served[t]
-                * q_eff**QUALITY_EXPONENT
+                * q**QUALITY_EXPONENT
                 * v**VOLUME_EXPONENT
             )
 

--- a/neurons/validators/scoring/query_scheduler.py
+++ b/neurons/validators/scoring/query_scheduler.py
@@ -24,7 +24,7 @@ ORGANIC_DEEP_CAP_PER_TYPE = 100
 QUALITY_EXPONENT = 2.0
 VOLUME_EXPONENT = 1.2
 COVERAGE_EXPONENT = 2.0
-MIN_VOLUME_RATIO = 0.30
+MIN_VOLUME_RATIO = 0.50
 
 BATCH_SIZE = 20
 BATCH_INTERVAL_SECONDS = 3
@@ -38,12 +38,10 @@ DEEP_SAMPLE_WEIGHT = 5
 def combine_superlinear_scores(
     qualities_per_type: dict[str, dict[int, tuple[float, int]]],
 ) -> dict[int, float]:
-    """``score = coverage^CE * Σ w·served·q_eff^QE·v^VE`` (served = soft-floor v/max_v / MVR)"""
     all_uids: set[int] = set()
     for uid_q in qualities_per_type.values():
         all_uids.update(uid_q.keys())
 
-    threshold = capacity.QUALITY_THRESHOLD
     combined: dict[int, float] = {}
     for uid in all_uids:
         qv = {
@@ -54,7 +52,7 @@ def combine_superlinear_scores(
 
         served: dict[str, float] = {}
         for t, (q, v) in qv.items():
-            if max_v == 0 or q < threshold:
+            if max_v == 0 or q < capacity.QUALITY_THRESHOLDS[t]:
                 served[t] = 0.0
             else:
                 served[t] = min(1.0, (v / max_v) / MIN_VOLUME_RATIO)
@@ -65,7 +63,8 @@ def combine_superlinear_scores(
         for t, (q, v) in qv.items():
             if served[t] == 0.0:
                 continue
-            q_eff = (q - threshold) / (1.0 - threshold)
+            thr = capacity.QUALITY_THRESHOLDS[t]
+            q_eff = (q - thr) / (1.0 - thr)
             per_type_sum += (
                 SEARCH_TYPE_WEIGHTS[t]
                 * served[t]
@@ -399,7 +398,7 @@ class QueryScheduler:
         }
 
         for uid, (quality, _) in uid_results.items():
-            await capacity.update_after_scoring(
+            await capacity.record_window_quality(
                 uid=uid,
                 search_type=search_type,
                 quality=quality,
@@ -455,6 +454,11 @@ class QueryScheduler:
                 )
                 if uid_results:
                     qualities_per_type[search_type] = uid_results
+
+            touched_uids = sorted(
+                {uid for results in qualities_per_type.values() for uid in results}
+            )
+            await capacity.ramp_after_epoch(touched_uids)
 
             combined = combine_superlinear_scores(qualities_per_type)
             await self._dispatch_combined_scores(combined)

--- a/neurons/validators/scrapers/web_scraper_validator.py
+++ b/neurons/validators/scrapers/web_scraper_validator.py
@@ -22,6 +22,7 @@ from neurons.validators.penalty.result_schema_penalty import ResultSchemaPenalty
 from neurons.validators.penalty.timeout_penalty import TimeoutPenaltyModel
 from neurons.validators.reward import RewardScoringType
 from neurons.validators.reward.performance_reward import PerformanceRewardModel
+from neurons.validators.reward.reward_llm import RewardLLM
 from neurons.validators.reward.web_basic_search_content_relevance import (
     WebBasicSearchContentRelevanceModel,
 )
@@ -40,6 +41,8 @@ class WebScraperValidator(BaseScraperValidator):
         self.web_content_weight = 0.70
         self.performance_weight = 0.30
 
+        self.reward_llm = RewardLLM(neuron.config.neuron.scoring_model)
+
         reward_weights = np.array(
             [
                 self.web_content_weight,
@@ -52,6 +55,7 @@ class WebScraperValidator(BaseScraperValidator):
             WebBasicSearchContentRelevanceModel(
                 scoring_type=RewardScoringType.search_relevance_score_template,
                 neuron=neuron,
+                llm_reward=self.reward_llm,
             ),
             PerformanceRewardModel(
                 neuron=neuron,

--- a/neurons/validators/scrapers/web_scraper_validator.py
+++ b/neurons/validators/scrapers/web_scraper_validator.py
@@ -36,7 +36,7 @@ class WebScraperValidator(BaseScraperValidator):
 
     def __init__(self, neuron: AbstractNeuron):
         self.timeout = 180
-        self.max_execution_time = 10
+        self.max_execution_time = 5
 
         self.web_content_weight = 0.70
         self.performance_weight = 0.30

--- a/neurons/validators/utils/prompts.py
+++ b/neurons/validators/utils/prompts.py
@@ -195,6 +195,50 @@ class SearchSummaryRelevancePrompt(ScoringPrompt):
         return _extract_label_score(response)
 
 
+system_message_web_search_relevance_template = """You judge whether a web page is a relevant result for a search query — the way a normal search engine would. You see only the page's title and description (snippet), not the full page.
+
+RELEVANT — the page is genuinely about the query's topic: what someone running this search would reasonably expect to find. How-to pages, documentation, articles, news, forum threads, videos, overviews, and listing / hub pages all count as RELEVANT when they are on the query's topic.
+
+IRRELEVANT — the page is about a different topic and only matches the query through a shared common word. Example: the query is about "docker" but the result is a video titled "What hard work looks like" that matched only on the word "work". If the page's topic does not match the query's topic, it is IRRELEVANT.
+
+Be lenient: a search engine legitimately returns a wide range of on-topic results. Only answer IRRELEVANT when the topic genuinely does not match the query.
+
+Output exactly one word: RELEVANT or IRRELEVANT."""
+
+
+user_message_web_search_relevance_template = """
+<Query>
+{}
+</Query>
+
+<Result>
+{}
+</Result>
+"""
+
+
+class WebSearchRelevancePrompt(ScoringPrompt):
+    r"""Binary relevance for a plain web-search result (RELEVANT / IRRELEVANT) — topic match, not answer-bearing intent."""
+
+    def __init__(self):
+        super().__init__()
+        self.template = user_message_web_search_relevance_template
+        self.extract_pattern = r"(?i)\b(IRRELEVANT|RELEVANT)\b"
+
+    def get_system_message(self):
+        return system_message_web_search_relevance_template
+
+    def extract_score(self, response: str) -> float:
+        if not response:
+            return 0.0
+        text = response.upper()
+        if "IRRELEVANT" in text or "NOT RELEVANT" in text:
+            return 0.0
+        if "RELEVANT" in text:
+            return 1.0
+        return 0.0
+
+
 def find_unique_tags(input_text: str):
     r"""Find all substrings that match the pattern '<...>'."""
     matches = re.findall("<([^>]*)>", input_text)

--- a/neurons/validators/utils/web_query_operators.py
+++ b/neurons/validators/utils/web_query_operators.py
@@ -1,0 +1,46 @@
+import re
+from dataclasses import dataclass, field
+from typing import List
+from urllib.parse import urlparse
+
+_SITE_RE = re.compile(r"(?i)\bsite:(\S+)")
+
+
+@dataclass
+class WebQueryOperators:
+    """Operators parsed out of a raw web query, plus the query text with them stripped."""
+
+    text: str
+    sites: List[str] = field(default_factory=list)
+
+    def host_allowed(self, url: str) -> bool:
+        """True when no site: filter applies, or the URL host is one of the sites (or a subdomain)."""
+        if not self.sites:
+            return True
+
+        host = (urlparse(url).hostname or "").lower().rstrip(".")
+        if not host:
+            return False
+
+        return any(host == site or host.endswith("." + site) for site in self.sites)
+
+
+def _normalize_domain(raw: str) -> str:
+    domain = raw.strip().strip("/").lower()
+    domain = re.sub(r"^https?://", "", domain)
+    domain = domain.split("/", 1)[0]
+    return domain.rstrip(".")
+
+
+def parse_web_query(query: str) -> WebQueryOperators:
+    """Extract supported operators (only ``site:`` today) and return the cleaned query text."""
+    if not query:
+        return WebQueryOperators(text="")
+
+    sites = [
+        domain for raw in _SITE_RE.findall(query) if (domain := _normalize_domain(raw))
+    ]
+
+    stripped = re.sub(r"\s+", " ", _SITE_RE.sub("", query)).strip()
+
+    return WebQueryOperators(text=stripped, sites=sites)

--- a/tests/validators/reward/test_web_basic_search_content_relevance.py
+++ b/tests/validators/reward/test_web_basic_search_content_relevance.py
@@ -1,121 +1,373 @@
+import re
 import unittest
+
+from desearch.protocol import WebSearchSynapse, WebSearchValidatorResult
 from neurons.validators.reward.web_basic_search_content_relevance import (
+    WEB_LINK_SCRAPE_AMOUNT,
     WebBasicSearchContentRelevanceModel,
 )
-from desearch.protocol import WebSearchSynapse, WebSearchValidatorResult
+from neurons.validators.utils.web_query_operators import parse_web_query
 from tests_data.links.links import link1, link2, link3, link4, link5
 
+ALL_LINKS = (link1, link2, link3, link4, link5)
 
-class WebBasicSearchContentRelevanceModelTestCase(unittest.IsolatedAsyncioTestCase):
+
+def _validator_link(base, **overrides):
+    """A validator scrape whose page HTML contains the snippet (passes authenticity)."""
+    data = {**base, "html_text": base["snippet"], "html_content": base["snippet"]}
+    data.update(overrides)
+    return WebSearchValidatorResult(**data)
+
+
+def _excerpt_page(snippet: str) -> str:
+    """Page where the snippet appears as a contiguous excerpt within more text."""
+    return f"Welcome to our site. {snippet} Read more below in the full article."
+
+
+def _scrambled_page(snippet: str) -> str:
+    """Snippet's words present but adjacency broken — not an excerpt (e.g. JS page)."""
+    words = [w for w in re.split(r"\W+", snippet) if w]
+    return "site nav " + " and ".join(words) + " footer links"
+
+
+class FakeRewardLLM:
+    """Returns a fixed verdict per URL and records the conversations it scored."""
+
+    def __init__(self, verdicts):
+        self.verdicts = verdicts
+        self.scored = []
+
+    async def llm_processing(self, messages):
+        result = {}
+        for message in messages:
+            ((url, conversation),) = message.items()
+            self.scored.append((url, conversation))
+            result[url] = self.verdicts.get(url, "IRRELEVANT")
+        return result
+
+
+class CheckResponseRandomLinkTestCase(unittest.IsolatedAsyncioTestCase):
+    """Gate logic in isolation: relevance is supplied directly, no LLM/network."""
+
     def setUp(self):
-        self.scoring_type = None
         self.model = WebBasicSearchContentRelevanceModel(
-            self.scoring_type, neuron=None
+            scoring_type=None, neuron=None, llm_reward=None
         )
 
-    async def test_get_rewards(self):
-        rewards, grouped_score = await self.model.get_rewards(
-            [
-                WebSearchSynapse(query="python", results=[link1, link2]),
-                WebSearchSynapse(query="python", results=[link2, link3]),
-                WebSearchSynapse(query="python", results=[link1, link4, link5]),
-            ],
-            [
-                1,
-                2,
-                3,
-            ],
+    def _synapse(self, validator_links, query="python"):
+        return WebSearchSynapse(
+            query=query, results=list(ALL_LINKS), validator_links=validator_links
         )
 
-        self.assertEqual(len(rewards), 3)
-        self.assertEqual(rewards[0].reward, 0.5)
-        self.assertEqual(rewards[1].reward, 1)
-        self.assertEqual(rewards[2].reward, 0)
-        self.assertEqual(grouped_score, {1: 0.5, 2: 1, 3: 0})
-
-    async def test_process_links(self):
-        synapse = WebSearchSynapse(
-            query="python", results=[link1, link2, link3, link4, link5]
+    def test_relevance_score_passes_through(self):
+        synapse = self._synapse([_validator_link(link1), _validator_link(link2)])
+        score = self.model.check_response_random_link(
+            synapse, {link1["link"]: 1.0, link2["link"]: 1.0}
         )
+        self.assertEqual(score, 1.0)
 
-        await self.model.process_links([synapse])
+    def test_offtopic_link_scores_zero(self):
+        # The customer's bug: a real page matched on one common word is now rejected.
+        synapse = self._synapse([_validator_link(link1)])
+        score = self.model.check_response_random_link(synapse, {link1["link"]: 0.0})
+        self.assertEqual(score, 0.0)
 
-        self.assertEqual(len(synapse.validator_links), 2)
+    def test_mixed_relevance_averages(self):
+        synapse = self._synapse([_validator_link(link1), _validator_link(link2)])
+        score = self.model.check_response_random_link(
+            synapse, {link1["link"]: 1.0, link2["link"]: 0.0}
+        )
+        self.assertEqual(score, 0.5)
 
-        links = [link["link"] for link in synapse.results]
-        self.assertTrue(all(item.link in links for item in synapse.validator_links))
+    def test_missing_verdict_is_skipped_not_zeroed(self):
+        synapse = self._synapse([_validator_link(link1), _validator_link(link2)])
+        # link2 has no verdict (e.g. scoring outage) -> skipped, not counted as 0.
+        score = self.model.check_response_random_link(synapse, {link1["link"]: 1.0})
+        self.assertEqual(score, 1.0)
 
-    async def test_check_respones_random_link(self):
+    def test_authenticity_gates_zero_regardless_of_relevance(self):
+        relevant = {link1["link"]: 1.0, "wrong link": 1.0}
+
+        cases = {
+            "no validator links": [],
+            "title mismatch": [_validator_link(link1, title="totally different title")],
+            "link mismatch": [_validator_link(link1, link="wrong link")],
+        }
+
+        for description, validator_links in cases.items():
+            score = self.model.check_response_random_link(
+                self._synapse(validator_links), relevant
+            )
+            self.assertEqual(score, 0.0, description)
+
+    def test_duplicate_miner_link_zeroes_response(self):
         synapse = WebSearchSynapse(
             query="python",
-            results=[link1, link2, link3, link4, link5],
-            validator_links=[
-                WebSearchValidatorResult(**link1, html_text=link1["snippet"]),
-                WebSearchValidatorResult(**link2, html_content=link2["snippet"]),
-            ],
+            results=[link1, link1],
+            validator_links=[_validator_link(link1)],
+        )
+        score = self.model.check_response_random_link(synapse, {link1["link"]: 1.0})
+        self.assertEqual(score, 0.0)
+
+
+class SnippetAuthenticityTestCase(unittest.IsolatedAsyncioTestCase):
+    """Tolerant snippet check: content-first with meta-description fallback + anti-gaming."""
+
+    def setUp(self):
+        self.model = WebBasicSearchContentRelevanceModel(
+            scoring_type=None, neuron=None, llm_reward=None
         )
 
-        result = self.model.check_response_random_link(synapse)
-        self.assertEqual(result, 1)
+    def _synapse(self, validator_links, query="python"):
+        return WebSearchSynapse(
+            query=query, results=list(ALL_LINKS), validator_links=validator_links
+        )
 
-        for falseCase in [
-            {
-                "case": WebSearchSynapse(
-                    query="python",
-                    results=[link1, link2, link3, link4, link5],
-                    validator_links=[],
-                ),
-                "description": "should return 0 : no validator links",
-            },
-            {
-                "case": WebSearchSynapse(
-                    query="python",
-                    results=[link1, link2, link3, link4, link5],
-                    validator_links=[
-                        WebSearchValidatorResult(
-                            **link1,
-                        ),
-                        WebSearchValidatorResult(
-                            **link2,
-                        ),
-                    ],
-                ),
-                "description": "should return 0 : missing snippet in html content",
-            },
-            {
-                "case": WebSearchSynapse(
-                    query="python",
-                    results=[link1, link2, link3, link4, link5],
-                    validator_links=[
-                        {**link1, "html_text": link1["snippet"], "title": "wrong title"}
-                    ],
-                ),
-                "description": "should return 0 : incorrect title",
-            },
-            {
-                "case": WebSearchSynapse(
-                    query="python",
-                    results=[link1, link2, link3, link4, link5],
-                    validator_links=[
-                        {**link1, "html_text": link1["snippet"], "link": "wrong link"}
-                    ],
-                ),
-                "description": "should return 0 : incorrect link",
-            },
-            {
-                "case": WebSearchSynapse(
-                    query="blockchain",
-                    results=[link1, link2, link3, link4, link5],
-                    validator_links=[{**link1, "html_text": link1["snippet"]}],
-                ),
-                "description": "should return 0 : mismatching query",
-            },
-        ]:
-            self.assertEqual(
-                self.model.check_response_random_link(falseCase["case"]),
-                0,
-                falseCase["description"],
-            )
+    def test_excerpt_snippet_passes_via_page_content(self):
+        page = _excerpt_page(link1["snippet"])
+        vlink = _validator_link(link1, html_text=page, html_content=page, snippet="")
+        score = self.model.check_response_random_link(
+            self._synapse([vlink]), {link1["link"]: 1.0}
+        )
+        self.assertEqual(score, 1.0)
+
+    def test_unverifiable_snippet_scores_zero(self):
+        page = _scrambled_page(link1["snippet"])
+        vlink = _validator_link(link1, html_text=page, html_content=page, snippet=page)
+        score = self.model.check_response_random_link(
+            self._synapse([vlink]), {link1["link"]: 1.0}
+        )
+        self.assertEqual(score, 0.0)
+
+    def test_filler_snippet_is_not_substantive(self):
+        for filler in (
+            "the the the the the the the the the the the",
+            "python python python python python python python python",
+        ):
+            self.assertFalse(self.model._is_substantive_snippet(filler))
+
+    def test_snippet_matches_via_meta_description_when_absent_from_body(self):
+        # Body is navigation chrome; the snippet lives only in the meta description.
+        vlink = _validator_link(
+            link1,
+            html_text="home about contact login menu",
+            html_content="home about contact login menu",
+            snippet=link1["snippet"],
+        )
+        score = self.model.check_response_random_link(
+            self._synapse([vlink]), {link1["link"]: 1.0}
+        )
+        self.assertEqual(score, 1.0)
+
+    def test_trivially_short_snippet_scores_zero(self):
+        # Anti-gaming: a one-word snippet matches anything, so it earns no credit.
+        gamed = {**link1, "snippet": "python"}
+        vlink = _validator_link(
+            gamed,
+            html_text="python " * 50,
+            html_content="python " * 50,
+            snippet="python",
+        )
+        synapse = WebSearchSynapse(
+            query="python", results=[gamed], validator_links=[vlink]
+        )
+        score = self.model.check_response_random_link(synapse, {link1["link"]: 1.0})
+        self.assertEqual(score, 0.0)
+
+    def test_empty_snippet_scores_zero(self):
+        empty = {**link1, "snippet": ""}
+        vlink = WebSearchValidatorResult(
+            title=link1["title"],
+            link=link1["link"],
+            snippet="",
+            html_text="anything at all here",
+            html_content="anything at all here",
+        )
+        synapse = WebSearchSynapse(
+            query="python", results=[empty], validator_links=[vlink]
+        )
+        score = self.model.check_response_random_link(synapse, {link1["link"]: 1.0})
+        self.assertEqual(score, 0.0)
+
+    def test_youtube_style_result_is_not_a_free_pass(self):
+        # A YouTube page's html_text IS its title+description, so the snippet always
+        # matches authenticity — but an off-topic video is still zeroed by relevance.
+        yt = {
+            "title": "What hard work looks like",
+            "snippet": "A motivational video about discipline, effort and grinding every single day.",
+            "link": "https://www.youtube.com/watch?v=abc123",
+            "date": None,
+        }
+        body = f"{yt['title']} {yt['snippet']}"
+        vlink = WebSearchValidatorResult(
+            title=yt["title"],
+            link=yt["link"],
+            snippet=yt["snippet"],
+            html_text=body,
+            html_content=body,
+        )
+        synapse = WebSearchSynapse(
+            query="how does docker work", results=[yt], validator_links=[vlink]
+        )
+
+        verified = self.model._snippet_verified(yt["snippet"], vlink)
+        offtopic = self.model.check_response_random_link(synapse, {yt["link"]: 0.0})
+        ontopic = self.model.check_response_random_link(synapse, {yt["link"]: 1.0})
+
+        self.assertTrue(verified)
+        self.assertEqual(offtopic, 0.0)
+        self.assertEqual(ontopic, 1.0)
+
+
+class SiteOperatorTestCase(unittest.IsolatedAsyncioTestCase):
+    """`site:` gate on result host + stripping from the LLM relevance text."""
+
+    def setUp(self):
+        self.model = WebBasicSearchContentRelevanceModel(
+            scoring_type=None, neuron=None, llm_reward=None
+        )
+
+    def test_in_domain_result_passes(self):
+        # link1 host is www.python.org, a subdomain match for site:python.org.
+        synapse = WebSearchSynapse(
+            query="python site:python.org",
+            results=[link1],
+            validator_links=[_validator_link(link1)],
+        )
+        score = self.model.check_response_random_link(synapse, {link1["link"]: 1.0})
+        self.assertEqual(score, 1.0)
+
+    def test_out_of_domain_result_scores_zero(self):
+        # link2 host is www.w3schools.com — not under python.org.
+        synapse = WebSearchSynapse(
+            query="python site:python.org",
+            results=[link2],
+            validator_links=[_validator_link(link2)],
+        )
+        score = self.model.check_response_random_link(synapse, {link2["link"]: 1.0})
+        self.assertEqual(score, 0.0)
+
+    async def test_site_operator_stripped_from_relevance_text(self):
+        captured = {}
+
+        class CapturingLLM:
+            async def llm_processing(self, messages):
+                for message in messages:
+                    ((url, conversation),) = message.items()
+                    captured[url] = conversation[1]["content"]
+                return {url: "RELEVANT" for url in captured}
+
+        self.model.reward_llm = CapturingLLM()
+        synapse = WebSearchSynapse(
+            query="machine learning site:python.org", results=[link1]
+        )
+        synapse.validator_links = [_validator_link(link1)]
+
+        await self.model.llm_process_validator_links(synapse)
+
+        user_content = captured[link1["link"]]
+        self.assertIn("machine learning", user_content)
+        self.assertNotIn("site:python.org", user_content)
+
+    def test_parse_only_handles_site_operator(self):
+        # Only site: is supported today; other tokens stay in the query text.
+        operators = parse_web_query("filetype:pdf python site:docs.python.org")
+        self.assertEqual(operators.sites, ["docs.python.org"])
+        self.assertIn("filetype:pdf", operators.text)
+        self.assertNotIn("site:", operators.text)
+
+
+class WebSearchRelevancePromptTestCase(unittest.TestCase):
+    def setUp(self):
+        from neurons.validators.utils.prompts import WebSearchRelevancePrompt
+
+        self.prompt = WebSearchRelevancePrompt()
+
+    def test_relevant_scores_one(self):
+        self.assertEqual(self.prompt.extract_score("RELEVANT"), 1.0)
+        self.assertEqual(self.prompt.extract_score("Verdict: relevant"), 1.0)
+
+    def test_irrelevant_scores_zero_despite_containing_relevant(self):
+        # "IRRELEVANT" contains "RELEVANT" — must not be read as a pass.
+        self.assertEqual(self.prompt.extract_score("IRRELEVANT"), 0.0)
+        self.assertEqual(self.prompt.extract_score("This is not relevant"), 0.0)
+
+    def test_empty_or_garbled_scores_zero(self):
+        self.assertEqual(self.prompt.extract_score(""), 0.0)
+        self.assertEqual(self.prompt.extract_score("unsure"), 0.0)
+
+
+class WebBasicGetRewardsTestCase(unittest.IsolatedAsyncioTestCase):
+    """End-to-end get_rewards with the page scrape and LLM stubbed (no network)."""
+
+    def _model(self, verdicts):
+        model = WebBasicSearchContentRelevanceModel(
+            scoring_type=None, neuron=None, llm_reward=FakeRewardLLM(verdicts)
+        )
+        by_url = {link["link"]: link for link in ALL_LINKS}
+
+        async def fake_scrape_links(urls):
+            metadata = []
+            for url in urls:
+                link = by_url[url]
+                metadata.append(
+                    {
+                        "title": link["title"],
+                        "snippet": link["snippet"],
+                        "link": link["link"],
+                        "html_text": link["snippet"],
+                        "html_content": link["snippet"],
+                    }
+                )
+            return metadata, []
+
+        model.scrape_links = fake_scrape_links
+        return model
+
+    async def test_process_links_populates_validator_links(self):
+        model = self._model({})
+        synapse = WebSearchSynapse(query="python", results=list(ALL_LINKS))
+
+        await model.process_links([synapse])
+
+        self.assertEqual(len(synapse.validator_links), WEB_LINK_SCRAPE_AMOUNT)
+        result_urls = [r["link"] for r in synapse.results]
+        self.assertTrue(all(v.link in result_urls for v in synapse.validator_links))
+
+    async def test_relevant_links_score_full(self):
+        model = self._model({link["link"]: "RELEVANT" for link in ALL_LINKS})
+        rewards, grouped = await model.get_rewards(
+            [
+                WebSearchSynapse(query="python", results=[link1, link2]),
+                WebSearchSynapse(query="python", results=[link3, link4, link5]),
+            ],
+            [1, 2],
+        )
+        self.assertEqual([r.reward for r in rewards], [1.0, 1.0])
+        self.assertEqual(grouped, {1: 1.0, 2: 1.0})
+
+    async def test_offtopic_links_score_zero_end_to_end(self):
+        model = self._model({link["link"]: "IRRELEVANT" for link in ALL_LINKS})
+        rewards, grouped = await model.get_rewards(
+            [WebSearchSynapse(query="python", results=[link1, link2])], [7]
+        )
+        self.assertEqual(rewards[0].reward, 0.0)
+        self.assertEqual(grouped, {7: 0.0})
+
+    async def test_llm_judges_query_against_validator_scraped_text(self):
+        model = self._model({link1["link"]: "RELEVANT", link2["link"]: "RELEVANT"})
+        synapse = WebSearchSynapse(
+            query="how does docker work", results=[link1, link2]
+        )
+
+        await model.get_rewards([synapse], [1])
+
+        self.assertTrue(model.reward_llm.scored)
+        scored_url, conversation = model.reward_llm.scored[0]
+        user_content = conversation[1]["content"]
+        self.assertIn("how does docker work", user_content)
+        scraped_title = {link["link"]: link["title"] for link in ALL_LINKS}[scored_url]
+        self.assertIn(scraped_title, user_content)
 
 
 if __name__ == "__main__":

--- a/tests/validators/test_capacity.py
+++ b/tests/validators/test_capacity.py
@@ -4,66 +4,103 @@ import pytest
 
 from neurons.validators.scoring import capacity, miner_db
 from neurons.validators.scoring.capacity import (
-    DECAY_FRACTION,
     DEFAULT_PER_UID,
     HARD_CAP_PER_UID,
-    QUALITY_THRESHOLD,
+    QUALITY_THRESHOLDS,
     RAMP_FRACTION,
     UNREACHABLE_DECAY_INTERVAL_SEC,
-    UNREACHABLE_FAILURE_THRESHOLD,
     decay_unreachable_tick,
     next_verified,
     note_call_result,
+    passes_combined_gate,
+    ramp_after_epoch,
+    record_window_quality,
 )
 
 
-def test_ramp_up_when_quality_passes():
-    """At quality >= threshold, verified grows by max(1, declared * RAMP_FRACTION)."""
-    assert next_verified(current=1, declared=100, quality_avg=0.9) == 11
-    assert next_verified(current=50, declared=100, quality_avg=0.5) == 60
+def test_ramp_up_when_gate_passes():
+    """all_pass=True grows verified by max(1, declared * RAMP_FRACTION)."""
+    assert next_verified(current=1, declared=100, all_pass=True) == 11
+    assert next_verified(current=50, declared=100, all_pass=True) == 60
 
 
-def test_ramp_down_when_quality_fails():
-    """Below threshold, decay step = DECAY_FRACTION * declared (faster than ramp)."""
-    assert next_verified(current=50, declared=100, quality_avg=0.1) == 30
-    assert DECAY_FRACTION > RAMP_FRACTION
+def test_ramp_down_when_gate_fails():
+    """all_pass=False shrinks verified by DECAY_FRACTION * declared."""
+    assert next_verified(current=50, declared=100, all_pass=False) == 40
 
 
 def test_decay_floors_at_default():
-    assert next_verified(current=5, declared=100, quality_avg=0.0) == DEFAULT_PER_UID
+    assert next_verified(current=5, declared=100, all_pass=False) == DEFAULT_PER_UID
 
 
 def test_ramp_caps_at_declared():
-    assert next_verified(current=95, declared=100, quality_avg=0.9) == 100
-    assert next_verified(current=24, declared=25, quality_avg=0.9) == 25
+    assert next_verified(current=95, declared=100, all_pass=True) == 100
+    assert next_verified(current=24, declared=25, all_pass=True) == 25
 
 
 def test_ramp_caps_at_hard_cap():
-    assert next_verified(current=95, declared=500, quality_avg=0.9) == HARD_CAP_PER_UID
+    assert next_verified(current=95, declared=500, all_pass=True) == HARD_CAP_PER_UID
 
 
 def test_ramp_step_minimum_one_for_small_declared():
-    """5 * 0.10 = 0.5, rounds to 0 — but ramp still moves by 1 per epoch."""
+    """5 * 0.10 = 0.5 → rounds to 0, but step is floored to 1."""
     assert int(5 * RAMP_FRACTION) == 0
-    assert next_verified(current=1, declared=5, quality_avg=0.9) == 2
-    assert next_verified(current=3, declared=5, quality_avg=0.0) == 2
-
-
-def test_threshold_exactly_qualifies():
-    assert next_verified(current=10, declared=100, quality_avg=QUALITY_THRESHOLD) == 20
-    assert (
-        next_verified(current=10, declared=100, quality_avg=QUALITY_THRESHOLD - 0.001)
-        == 0
-        or next_verified(
-            current=10, declared=100, quality_avg=QUALITY_THRESHOLD - 0.001
-        )
-        == DEFAULT_PER_UID
-    )
+    assert next_verified(current=1, declared=5, all_pass=True) == 2
+    assert next_verified(current=3, declared=5, all_pass=False) == 2
 
 
 def test_declared_below_default_clamps():
-    """Bogus declared=0 is treated as DEFAULT_PER_UID for step purposes."""
-    assert next_verified(current=1, declared=0, quality_avg=0.9) == DEFAULT_PER_UID
+    """declared=0 still floors step to 1."""
+    assert next_verified(current=1, declared=0, all_pass=True) == DEFAULT_PER_UID
+
+
+def test_gate_passes_when_all_above_thresholds():
+    ema = {"ai_search": 0.46, "x_search": 0.61, "web_search": 0.61}
+    declared = {"ai_search": 100, "x_search": 100, "web_search": 100}
+    assert passes_combined_gate(ema, declared) is True
+
+
+def test_gate_fails_when_ai_below_threshold():
+    ema = {"ai_search": 0.20, "x_search": 0.80, "web_search": 0.80}
+    declared = {"ai_search": 100, "x_search": 100, "web_search": 100}
+    assert passes_combined_gate(ema, declared) is False
+
+
+def test_gate_fails_when_x_below_threshold():
+    ema = {"ai_search": 0.90, "x_search": 0.40, "web_search": 0.90}
+    declared = {"ai_search": 100, "x_search": 100, "web_search": 100}
+    assert passes_combined_gate(ema, declared) is False
+
+
+def test_gate_fails_when_web_below_threshold():
+    ema = {"ai_search": 0.90, "x_search": 0.90, "web_search": 0.49}
+    declared = {"ai_search": 100, "x_search": 100, "web_search": 100}
+    assert passes_combined_gate(ema, declared) is False
+
+
+def test_gate_fails_when_any_declared_zero():
+    """A miner who doesn't advertise AI can never ramp anything."""
+    ema = {"ai_search": 0.90, "x_search": 0.90, "web_search": 0.90}
+    declared = {"ai_search": 0, "x_search": 100, "web_search": 100}
+    assert passes_combined_gate(ema, declared) is False
+
+
+def test_gate_fails_when_type_missing():
+    """If a type is absent from the EMA/declared dicts, treat as fail."""
+    ema = {"ai_search": 0.90, "x_search": 0.90}
+    declared = {"ai_search": 100, "x_search": 100}
+    assert passes_combined_gate(ema, declared) is False
+
+
+def test_gate_threshold_exact_boundary():
+    """quality_avg == threshold qualifies (>= comparison)."""
+    ema = {
+        "ai_search": QUALITY_THRESHOLDS["ai_search"],
+        "x_search": QUALITY_THRESHOLDS["x_search"],
+        "web_search": QUALITY_THRESHOLDS["web_search"],
+    }
+    declared = {"ai_search": 100, "x_search": 100, "web_search": 100}
+    assert passes_combined_gate(ema, declared) is True
 
 
 @pytest.fixture
@@ -73,18 +110,111 @@ async def db(tmp_path):
     await miner_db.close()
 
 
-async def _seed_unreachable(uid: int, verified: int, unreachable_since: str):
-    await miner_db.register_miner(
-        uid=uid, search_type="x_search", declared=100, hotkey=f"h{uid}", coldkey="c"
-    )
-    await miner_db.bulk_update_verified("x_search", {uid: verified})
-    async with miner_db._conn() as conn:
-        await conn.execute(
-            "UPDATE miner_concurrency SET unreachable_since=?, last_decay_at=? "
-            "WHERE uid=? AND search_type='x_search'",
-            (unreachable_since, unreachable_since, uid),
+async def _register_all_types(uid: int, declared: dict[str, int], hotkey: str = "h"):
+    for t, d in declared.items():
+        await miner_db.register_miner(
+            uid=uid, search_type=t, declared=d, hotkey=hotkey, coldkey="c"
         )
-        await conn.commit()
+
+
+async def _set_ema_and_verified(uid: int, by_type: dict[str, tuple[float, int]]):
+    for t, (ema, verified) in by_type.items():
+        await miner_db.upsert_quality_avg(uid=uid, search_type=t, quality_avg=ema)
+        await miner_db.bulk_update_verified(t, {uid: verified})
+
+
+async def test_ramp_after_epoch_ramps_all_three_when_gate_passes(db):
+    """All EMAs above threshold → all three verifieds step up together."""
+    await _register_all_types(
+        uid=1, declared={"ai_search": 100, "x_search": 100, "web_search": 100}
+    )
+    await _set_ema_and_verified(
+        uid=1,
+        by_type={
+            "ai_search": (0.7, 50),
+            "x_search": (0.7, 50),
+            "web_search": (0.7, 50),
+        },
+    )
+
+    await ramp_after_epoch([1])
+
+    for t in ("ai_search", "x_search", "web_search"):
+        row = await miner_db.get_concurrency_row(1, t)
+        assert row["verified"] == 60
+
+
+async def test_ramp_after_epoch_decays_all_three_when_ai_fails(db):
+    """AI EMA below threshold → all three verifieds decay together, even
+    though X+Web are individually fine."""
+    await _register_all_types(
+        uid=2, declared={"ai_search": 100, "x_search": 100, "web_search": 100}
+    )
+    await _set_ema_and_verified(
+        uid=2,
+        by_type={
+            "ai_search": (0.10, 100),
+            "x_search": (0.90, 100),
+            "web_search": (0.90, 100),
+        },
+    )
+
+    await ramp_after_epoch([2])
+
+    for t in ("ai_search", "x_search", "web_search"):
+        row = await miner_db.get_concurrency_row(2, t)
+        assert row["verified"] == 90
+
+
+async def test_ramp_after_epoch_decays_when_undeclared_type(db):
+    """declared=0 on AI → gate fails → all three decay."""
+    await _register_all_types(
+        uid=3, declared={"ai_search": 0, "x_search": 100, "web_search": 100}
+    )
+    await _set_ema_and_verified(
+        uid=3,
+        by_type={
+            "ai_search": (0.0, 1),
+            "x_search": (0.90, 100),
+            "web_search": (0.90, 100),
+        },
+    )
+
+    await ramp_after_epoch([3])
+
+    for t in ("x_search", "web_search"):
+        row = await miner_db.get_concurrency_row(3, t)
+        assert row["verified"] == 90
+
+
+async def test_ramp_after_epoch_handles_empty_uid_list(db):
+    await ramp_after_epoch([])
+
+
+async def test_record_window_quality_updates_ema_without_ramping(db):
+    await _register_all_types(
+        uid=4, declared={"ai_search": 100, "x_search": 100, "web_search": 100}
+    )
+    await _set_ema_and_verified(
+        uid=4,
+        by_type={
+            "ai_search": (0.0, 50),
+            "x_search": (0.0, 50),
+            "web_search": (0.0, 50),
+        },
+    )
+
+    await record_window_quality(
+        uid=4,
+        search_type="ai_search",
+        quality=1.0,
+        window_start="2026-05-20T00:00:00+00:00",
+        allocated=50,
+    )
+
+    row = await miner_db.get_concurrency_row(4, "ai_search")
+    assert row["quality_avg"] == pytest.approx(capacity.QUALITY_EMA_ALPHA)
+    assert row["verified"] == 50
 
 
 async def test_decay_single_tick_after_one_interval(db):
@@ -170,4 +300,18 @@ async def test_recovery_clears_last_decay_at(db):
     row = await miner_db.get_concurrency_row(6, "x_search")
     assert row["unreachable_since"] is None
     assert row["last_decay_at"] is None
-    assert row["verified"] == 72  # decayed value preserved across recovery
+    assert row["verified"] == 72
+
+
+async def _seed_unreachable(uid: int, verified: int, unreachable_since: str):
+    await miner_db.register_miner(
+        uid=uid, search_type="x_search", declared=100, hotkey=f"h{uid}", coldkey="c"
+    )
+    await miner_db.bulk_update_verified("x_search", {uid: verified})
+    async with miner_db._conn() as conn:
+        await conn.execute(
+            "UPDATE miner_concurrency SET unreachable_since=?, last_decay_at=? "
+            "WHERE uid=? AND search_type='x_search'",
+            (unreachable_since, unreachable_since, uid),
+        )
+        await conn.commit()

--- a/tests/validators/test_query_scheduler.py
+++ b/tests/validators/test_query_scheduler.py
@@ -4,8 +4,9 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from neurons.validators.scoring.capacity import QUALITY_THRESHOLD
+from neurons.validators.scoring.capacity import QUALITY_THRESHOLDS
 from neurons.validators.scoring.query_scheduler import (
+    MIN_VOLUME_RATIO,
     QueryScheduler,
     combine_superlinear_scores,
 )
@@ -21,7 +22,14 @@ def _uniform(q: float, v: int, uid: int = 1) -> dict:
 
 
 def test_combine_at_quality_threshold_earns_zero():
-    out = combine_superlinear_scores(_uniform(QUALITY_THRESHOLD, 100))
+    """At each type's threshold, q_eff = 0 → all per-type contributions zero out."""
+    out = combine_superlinear_scores(
+        {
+            "ai_search": {1: (QUALITY_THRESHOLDS["ai_search"], 100)},
+            "x_search": {1: (QUALITY_THRESHOLDS["x_search"], 100)},
+            "web_search": {1: (QUALITY_THRESHOLDS["web_search"], 100)},
+        }
+    )
     assert out[1] == 0.0
 
 
@@ -52,7 +60,9 @@ def test_combine_solo_beats_same_quality_split():
 
 
 def test_combine_split_uids_lose_to_higher_quality_solo():
-    """1 UID at q=0.5 outearns 2 UIDs at q=0.4 each, even with 2x infrastructure."""
+    """1 UID at q=0.5 outearns 2 UIDs at q=0.4 each. Under per-type thresholds
+    the split's X+Web fail (q<0.50) so they collapse to AI-only coverage=0.6;
+    the solo keeps full coverage=1.0 with AI contributing."""
     solo = combine_superlinear_scores(_uniform(0.5, 100, uid=1))
     split = combine_superlinear_scores(
         {
@@ -65,10 +75,35 @@ def test_combine_split_uids_lose_to_higher_quality_solo():
 
 
 def test_combine_quality_gap_amplification_is_quadratic():
-    """A 0.10 quality gap produces a (Δq_eff)² reward gap — steep near threshold."""
-    a = combine_superlinear_scores(_uniform(0.5, 100, uid=1))
-    b = combine_superlinear_scores(_uniform(0.4, 100, uid=2))
-    expected = ((0.5 - QUALITY_THRESHOLD) / (0.4 - QUALITY_THRESHOLD)) ** 2
+    """A 0.10 quality gap produces a (Δq_eff)² reward gap — steep near each
+    type's threshold. Both AI qualities are above the 0.45 threshold so both pass."""
+    a = combine_superlinear_scores(
+        {
+            "ai_search": {1: (0.6, 100)},
+            "x_search": {1: (0.7, 100)},
+            "web_search": {1: (0.7, 100)},
+        }
+    )
+    b = combine_superlinear_scores(
+        {
+            "ai_search": {2: (0.5, 100)},
+            "x_search": {2: (0.7, 100)},
+            "web_search": {2: (0.7, 100)},
+        }
+    )
+    ai_thr = QUALITY_THRESHOLDS["ai_search"]
+    x_thr = QUALITY_THRESHOLDS["x_search"]
+    web_thr = QUALITY_THRESHOLDS["web_search"]
+    # Total = coverage² · Σ w·q_eff² (·100^1.2 cancels in ratio). Both have
+    # coverage=1 (all 3 served). Compare full per_type_sums.
+    def per_type(q_ai, q_x, q_web):
+        return (
+            0.6 * ((q_ai - ai_thr) / (1 - ai_thr)) ** 2
+            + 0.2 * ((q_x - x_thr) / (1 - x_thr)) ** 2
+            + 0.2 * ((q_web - web_thr) / (1 - web_thr)) ** 2
+        )
+
+    expected = per_type(0.6, 0.7, 0.7) / per_type(0.5, 0.7, 0.7)
     assert a[1] / b[2] == pytest.approx(expected, rel=0.001)
 
 
@@ -101,7 +136,7 @@ def test_combine_xweb_specialist_earns_some_not_zero():
 
 
 def test_combine_volume_floor_partial_credit_below_threshold():
-    """v=10 on AI (10% of max=100) gets soft credit 0.333, not zero."""
+    """AI volume below the floor (10% of max=100) gets soft partial credit, not zero."""
     out = combine_superlinear_scores(
         {
             "ai_search": {1: (1.0, 10)},
@@ -109,9 +144,7 @@ def test_combine_volume_floor_partial_credit_below_threshold():
             "web_search": {1: (1.0, 100)},
         }
     )
-    # served_ai = min(1, (10/100)/0.30) = 0.3333
-    # served_x = served_web = 1.0
-    soft_ai = (10 / 100) / 0.30
+    soft_ai = min(1.0, (10 / 100) / MIN_VOLUME_RATIO)
     coverage = 0.60 * soft_ai + 0.20 * 1.0 + 0.20 * 1.0
     per_type = (
         0.60 * soft_ai * 1.0 * 10**1.2
@@ -122,23 +155,24 @@ def test_combine_volume_floor_partial_credit_below_threshold():
 
 
 def test_combine_volume_floor_full_credit_at_minimum():
-    """v=30 on AI (exactly 30% of max=100) gets full credit."""
+    """AI volume exactly at the floor (MIN_VOLUME_RATIO of max=100) gets full credit."""
+    floor_v = round(MIN_VOLUME_RATIO * 100)
     out = combine_superlinear_scores(
         {
-            "ai_search": {1: (1.0, 30)},
+            "ai_search": {1: (1.0, floor_v)},
             "x_search": {1: (1.0, 100)},
             "web_search": {1: (1.0, 100)},
         }
     )
-    # All three served at full credit.
+    # All three served at full credit (coverage = 1.0).
     expected_per_type = (
-        0.60 * 1.0 * 30**1.2 + 0.20 * 1.0 * 100**1.2 + 0.20 * 1.0 * 100**1.2
+        0.60 * 1.0 * floor_v**1.2 + 0.20 * 1.0 * 100**1.2 + 0.20 * 1.0 * 100**1.2
     )
     assert out[1] == pytest.approx(expected_per_type)
 
 
 def test_combine_volume_floor_no_cliff():
-    """v_ai crossing the 30% boundary changes the score smoothly, not 8x."""
+    """v_ai crossing the floor boundary changes the score smoothly, not 8x."""
 
     def score_at(v_ai):
         return combine_superlinear_scores(
@@ -149,9 +183,10 @@ def test_combine_volume_floor_no_cliff():
             }
         )[1]
 
-    s29, s30, s31 = score_at(29), score_at(30), score_at(31)
-    assert s30 / s29 < 1.10  # was 8.46x under the old binary floor
-    assert s31 / s30 < 1.10
+    b = round(MIN_VOLUME_RATIO * 100)
+    below, at, above = score_at(b - 1), score_at(b), score_at(b + 1)
+    assert at / below < 1.10  # was 8.46x under the old binary floor
+    assert above / at < 1.10
 
 
 def test_combine_generalist_beats_x_only_spam_team():

--- a/tests/validators/test_query_scheduler.py
+++ b/tests/validators/test_query_scheduler.py
@@ -6,7 +6,11 @@ import pytest
 
 from neurons.validators.scoring.capacity import QUALITY_THRESHOLDS
 from neurons.validators.scoring.query_scheduler import (
+    COVERAGE_EXPONENT,
     MIN_VOLUME_RATIO,
+    QUALITY_EXPONENT,
+    SEARCH_TYPE_WEIGHTS,
+    VOLUME_EXPONENT,
     QueryScheduler,
     combine_superlinear_scores,
 )
@@ -21,8 +25,9 @@ def _uniform(q: float, v: int, uid: int = 1) -> dict:
     }
 
 
-def test_combine_at_quality_threshold_earns_zero():
-    """At each type's threshold, q_eff = 0 → all per-type contributions zero out."""
+def test_combine_at_threshold_earns_positive():
+    """Raw q (not q_eff): a type exactly at its threshold passes the gate and earns
+    q**QUALITY_EXPONENT credit — it is no longer zeroed."""
     out = combine_superlinear_scores(
         {
             "ai_search": {1: (QUALITY_THRESHOLDS["ai_search"], 100)},
@@ -30,7 +35,7 @@ def test_combine_at_quality_threshold_earns_zero():
             "web_search": {1: (QUALITY_THRESHOLDS["web_search"], 100)},
         }
     )
-    assert out[1] == 0.0
+    assert out[1] > 0.0
 
 
 def test_combine_below_floor_clamps_to_zero():
@@ -60,9 +65,8 @@ def test_combine_solo_beats_same_quality_split():
 
 
 def test_combine_split_uids_lose_to_higher_quality_solo():
-    """1 UID at q=0.5 outearns 2 UIDs at q=0.4 each. Under per-type thresholds
-    the split's X+Web fail (q<0.50) so they collapse to AI-only coverage=0.6;
-    the solo keeps full coverage=1.0 with AI contributing."""
+    """1 UID at q=0.5 outearns 2 UIDs at q=0.4 each: the split fails every gate
+    (ai<0.45, x/web<0.60) and scores 0, while the solo passes the AI gate."""
     solo = combine_superlinear_scores(_uniform(0.5, 100, uid=1))
     split = combine_superlinear_scores(
         {
@@ -71,12 +75,13 @@ def test_combine_split_uids_lose_to_higher_quality_solo():
             "web_search": {2: (0.4, 100), 3: (0.4, 100)},
         }
     )
+    # split q=0.4 fails every gate (ai<0.45, x/web<0.60) -> 0; solo passes AI.
     assert solo[1] > split[2] + split[3]
 
 
-def test_combine_quality_gap_amplification_is_quadratic():
-    """A 0.10 quality gap produces a (Δq_eff)² reward gap — steep near each
-    type's threshold. Both AI qualities are above the 0.45 threshold so both pass."""
+def test_combine_quality_gap_amplified_by_raw_q():
+    """A 0.10 AI-quality gap produces a raw q**QUALITY_EXPONENT reward gap. Both AI
+    qualities clear 0.45 and x/web clear 0.60, so coverage=1 for both (v cancels)."""
     a = combine_superlinear_scores(
         {
             "ai_search": {1: (0.6, 100)},
@@ -91,16 +96,12 @@ def test_combine_quality_gap_amplification_is_quadratic():
             "web_search": {2: (0.7, 100)},
         }
     )
-    ai_thr = QUALITY_THRESHOLDS["ai_search"]
-    x_thr = QUALITY_THRESHOLDS["x_search"]
-    web_thr = QUALITY_THRESHOLDS["web_search"]
-    # Total = coverage² · Σ w·q_eff² (·100^1.2 cancels in ratio). Both have
-    # coverage=1 (all 3 served). Compare full per_type_sums.
+
     def per_type(q_ai, q_x, q_web):
         return (
-            0.6 * ((q_ai - ai_thr) / (1 - ai_thr)) ** 2
-            + 0.2 * ((q_x - x_thr) / (1 - x_thr)) ** 2
-            + 0.2 * ((q_web - web_thr) / (1 - web_thr)) ** 2
+            SEARCH_TYPE_WEIGHTS["ai_search"] * q_ai**QUALITY_EXPONENT
+            + SEARCH_TYPE_WEIGHTS["x_search"] * q_x**QUALITY_EXPONENT
+            + SEARCH_TYPE_WEIGHTS["web_search"] * q_web**QUALITY_EXPONENT
         )
 
     expected = per_type(0.6, 0.7, 0.7) / per_type(0.5, 0.7, 0.7)
@@ -108,7 +109,7 @@ def test_combine_quality_gap_amplification_is_quadratic():
 
 
 def test_combine_ai_specialist_gets_partial_credit():
-    """AI-only at q=1.0, v=100: only AI is served (coverage = 0.60)."""
+    """AI-only at q=1.0, v=100: only AI served, coverage = w_ai."""
     out = combine_superlinear_scores(
         {
             "ai_search": {1: (1.0, 100)},
@@ -116,13 +117,13 @@ def test_combine_ai_specialist_gets_partial_credit():
             "web_search": {1: (0.0, 0)},
         }
     )
-    # served = {ai}, coverage = 0.60, per_type = 0.60 * 1.0^2 * 100^1.2
-    expected = (0.60**2) * (0.60 * 1.0 * 100**1.2)
+    w = SEARCH_TYPE_WEIGHTS["ai_search"]
+    expected = w**COVERAGE_EXPONENT * (w * 1.0**QUALITY_EXPONENT * 100**VOLUME_EXPONENT)
     assert out[1] == pytest.approx(expected)
 
 
 def test_combine_xweb_specialist_earns_some_not_zero():
-    """X+Web at q=1.0 (no AI): coverage = 0.40, earns ~6% of perfect generalist."""
+    """X+Web at q=1.0 (no AI): coverage = w_x + w_web; earns coverage^(C+1) of a generalist."""
     specialist = combine_superlinear_scores(
         {
             "ai_search": {1: (0.0, 0)},
@@ -131,8 +132,10 @@ def test_combine_xweb_specialist_earns_some_not_zero():
         }
     )
     generalist = combine_superlinear_scores(_uniform(1.0, 100, uid=2))
+    cov = SEARCH_TYPE_WEIGHTS["x_search"] + SEARCH_TYPE_WEIGHTS["web_search"]
+    expected_ratio = cov**COVERAGE_EXPONENT * cov  # generalist coverage=1, q=v terms cancel
     assert specialist[1] > 0
-    assert specialist[1] / generalist[2] == pytest.approx(0.064, abs=0.005)
+    assert specialist[1] / generalist[2] == pytest.approx(expected_ratio, rel=0.01)
 
 
 def test_combine_volume_floor_partial_credit_below_threshold():
@@ -145,13 +148,14 @@ def test_combine_volume_floor_partial_credit_below_threshold():
         }
     )
     soft_ai = min(1.0, (10 / 100) / MIN_VOLUME_RATIO)
-    coverage = 0.60 * soft_ai + 0.20 * 1.0 + 0.20 * 1.0
+    w = SEARCH_TYPE_WEIGHTS
+    coverage = w["ai_search"] * soft_ai + w["x_search"] + w["web_search"]
     per_type = (
-        0.60 * soft_ai * 1.0 * 10**1.2
-        + 0.20 * 1.0 * 1.0 * 100**1.2
-        + 0.20 * 1.0 * 1.0 * 100**1.2
+        w["ai_search"] * soft_ai * 1.0**QUALITY_EXPONENT * 10**VOLUME_EXPONENT
+        + w["x_search"] * 1.0**QUALITY_EXPONENT * 100**VOLUME_EXPONENT
+        + w["web_search"] * 1.0**QUALITY_EXPONENT * 100**VOLUME_EXPONENT
     )
-    assert out[1] == pytest.approx(coverage**2 * per_type)
+    assert out[1] == pytest.approx(coverage**COVERAGE_EXPONENT * per_type)
 
 
 def test_combine_volume_floor_full_credit_at_minimum():
@@ -165,8 +169,11 @@ def test_combine_volume_floor_full_credit_at_minimum():
         }
     )
     # All three served at full credit (coverage = 1.0).
+    w = SEARCH_TYPE_WEIGHTS
     expected_per_type = (
-        0.60 * 1.0 * floor_v**1.2 + 0.20 * 1.0 * 100**1.2 + 0.20 * 1.0 * 100**1.2
+        w["ai_search"] * floor_v**VOLUME_EXPONENT
+        + w["x_search"] * 100**VOLUME_EXPONENT
+        + w["web_search"] * 100**VOLUME_EXPONENT
     )
     assert out[1] == pytest.approx(expected_per_type)
 
@@ -190,7 +197,7 @@ def test_combine_volume_floor_no_cliff():
 
 
 def test_combine_generalist_beats_x_only_spam_team():
-    """1 perfect generalist beats 10 X-only spammers by ~12.5×."""
+    """1 perfect generalist beats 10 X-only spammers (each only serves X → coverage = w_x)."""
     generalist = combine_superlinear_scores(_uniform(1.0, 100, uid=1))
     x_spam = combine_superlinear_scores(
         {
@@ -200,11 +207,14 @@ def test_combine_generalist_beats_x_only_spam_team():
         }
     )
     spam_total = sum(x_spam.values())
-    assert generalist[1] / spam_total == pytest.approx(12.5, rel=0.05)
+    wx = SEARCH_TYPE_WEIGHTS["x_search"]
+    per_spam = wx**COVERAGE_EXPONENT * wx  # ·100^V cancels vs the generalist
+    expected = 1.0 / (10 * per_spam)
+    assert generalist[1] / spam_total == pytest.approx(expected, rel=0.02)
 
 
 def test_combine_perfect_generalist_beats_perfect_specialist():
-    """Under 60/20/20 + weighted coverage², generalist >> AI-only specialist."""
+    """Under weighted coverage^C, a perfect generalist >> an AI-only specialist."""
     generalist = combine_superlinear_scores(_uniform(1.0, 100, uid=1))
     specialist = combine_superlinear_scores(
         {
@@ -213,9 +223,11 @@ def test_combine_perfect_generalist_beats_perfect_specialist():
             "web_search": {2: (0.0, 0)},
         }
     )
+    w_ai = SEARCH_TYPE_WEIGHTS["ai_search"]
     assert generalist[1] > specialist[2]
-    # Generalist earns ~4.6× the AI-only specialist (1.0 / (0.60^2 * 0.60) = 4.63)
-    assert generalist[1] / specialist[2] == pytest.approx(1 / (0.6**3), rel=0.001)
+    assert generalist[1] / specialist[2] == pytest.approx(
+        1 / (w_ai ** (COVERAGE_EXPONENT + 1)), rel=0.001
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Stronger web search scoring: results judged on real topic relevance and genuine snippets. Spam and keyword-only matches no longer earn credit.
- Reworked reward weighting: on-chain rewards follow the intended 80 / 10 / 10 split (AI / X / Web), with a quality bar and real-volume requirement per type.

## Web search scoring

- Off-topic or spam results now score 0.
- Each result's snippet is checked against the fetched page content. Only snippets that actually appear in the page count.
- Legitimate snippets that the old check wrongly failed now pass. Filler or keyword-stuffed snippets score 0.
- `site:` queries are enforced. Off-domain results don't count.
- Web responses now have a 5 second budget, down from 10.

**Web miners must return genuine page snippets and respond within 5 seconds.**

## Reward weighting across search types

- Rewards concentrate on AI search (80%). X and Web are 10% each.
- Each type needs a minimum quality to earn for it. AI bar is now 0.50. X and Web stay at 0.60.
- A token amount of a type no longer earns its weight. You need real volume, about half your busiest type.
- Falling below the quality bar on any one type lowers your volume on all three.

**Miners must serve all three types at quality and real volume, AI search especially (80% of weight).**