### PR TITLE
Improve synthetic scoring

### DIFF
--- a/desearch/__init__.py
+++ b/desearch/__init__.py
@@ -19,7 +19,7 @@
 
 
 # version must stay on line 22
-__version__ = "0.0.215"
+__version__ = "0.0.216"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/desearch/dataset/dataset.py
+++ b/desearch/dataset/dataset.py
@@ -1,4 +1,5 @@
 import random
+import re
 
 import bittensor as bt
 from faker import Faker
@@ -6,6 +7,76 @@ from faker import Faker
 from desearch.utils import call_openai
 
 QUESTION_MODEL = "gpt-4.1-nano"
+QUESTION_TEMPERATURE = 1.15
+
+QUESTION_ANGLES = [
+    "accessibility",
+    "adoption barriers",
+    "adoption incentives",
+    "community response",
+    "competition dynamics",
+    "competitive advantage",
+    "consumer impact",
+    "consumer trust",
+    "cost reduction",
+    "costs and tradeoffs",
+    "customer retention",
+    "energy demand",
+    "environmental impact",
+    "expert criticism",
+    "funding trends",
+    "infrastructure readiness",
+    "interoperability",
+    "international coordination",
+    "legal disputes",
+    "legal liability",
+    "long-term maintenance",
+    "labor impact",
+    "market impact",
+    "market concentration",
+    "measurement challenges",
+    "misinformation risks",
+    "platform governance",
+    "policy response",
+    "privacy impact",
+    "procurement challenges",
+    "product reliability",
+    "public sentiment",
+    "quality control",
+    "regional inequality",
+    "regional comparison",
+    "regulatory compliance",
+    "resource constraints",
+    "rural access",
+    "safety concerns",
+    "scaling challenges",
+    "security risks",
+    "scientific evidence",
+    "small business impact",
+    "standards and certification",
+    "stakeholder response",
+    "supply shortages",
+    "supply chain effects",
+    "technical limitations",
+    "urban implementation",
+    "workforce changes",
+]
+
+WEB_FALLBACK_TEMPLATES = [
+    "How is {topic} being adopted?",
+    "What are common challenges in {topic}?",
+    "What are key risks in {topic}?",
+    "What policies shape {topic}?",
+    "Which companies are leading {topic}?",
+]
+
+RESEARCH_FALLBACK_TEMPLATES = [
+    "How are companies approaching {topic}?",
+    "How are experts responding to {topic}?",
+    "What debates are shaping {topic}?",
+    "What risks are emerging around {topic}?",
+    "Which groups are affected by {topic}?",
+]
 
 TOPICS = [
     "renewable energy",
@@ -271,7 +342,6 @@ TOPICS = [
     "wearable tech",
     "deep learning",
     "cloud computing",
-    "content creation",
     "lab-grown meat",
     "precision fermentation",
     "floating wind farms",
@@ -292,12 +362,52 @@ TOPICS = [
 ]
 
 
+def _clean_question(question: str | None) -> str:
+    if not question:
+        return ""
+
+    lines = [line.strip() for line in question.splitlines() if line.strip()]
+    if not lines:
+        return ""
+
+    value = lines[0].strip().strip('"').strip("'")
+    value = value.split("\t", 1)[0]
+    value = re.split(r"\b(?:intent|label|category)\s*:", value, maxsplit=1, flags=re.I)[
+        0
+    ]
+    value = re.sub(r"^\s*(?:[-*]\s+|\d+[.)]\s*)", "", value).strip()
+    value = re.sub(r"\s+", " ", value)
+    if value and value[-1] not in "?!.":
+        value = f"{value}?"
+    return value.strip().strip('"').strip("'")
+
+
+class _TopicSampler:
+    def __init__(self, topics: list[str]) -> None:
+        self._topics = list(topics)
+        self._topic_pool: list[str] = []
+
+    @property
+    def topics(self) -> list[str]:
+        return list(self._topics)
+
+    def next_topic(self) -> str:
+        if not self._topics:
+            return "world events"
+
+        if not self._topic_pool:
+            self._topic_pool = list(self._topics)
+            random.shuffle(self._topic_pool)
+
+        return self._topic_pool.pop()
+
+
 class MockTwitterQuestionsDataset:
     """Exposes the shared topic list. Kept for backward compat with callers
     that access `.topics` directly (e.g. research scripts)."""
 
     def __init__(self):
-        self.topics = TOPICS
+        self.topics = list(TOPICS)
 
 
 class QuestionsDataset:
@@ -310,23 +420,41 @@ class QuestionsDataset:
     """
 
     def __init__(self) -> None:
-        self._topics = TOPICS
+        self._topic_sampler = _TopicSampler(TOPICS)
+        self._topics = self._topic_sampler.topics
 
     def _random_topic(self) -> str:
-        return random.choice(self._topics)
+        return self._topic_sampler.next_topic()
 
-    def _build_prompt(self, topic: str, selected_tools: list[str]) -> str:
+    def _fallback_question(self, topic: str, selected_tools: list[str]) -> str:
+        is_web_only = selected_tools == ["Web Search"]
+        templates = (
+            WEB_FALLBACK_TEMPLATES if is_web_only else RESEARCH_FALLBACK_TEMPLATES
+        )
+        return random.choice(templates).format(topic=topic)
+
+    def _build_prompt(
+        self,
+        topic: str,
+        selected_tools: list[str],
+        angle: str,
+    ) -> str:
         is_web_only = selected_tools == ["Web Search"]
 
         if is_web_only:
             return (
                 f'Generate ONE realistic web-search question about "{topic}".\n'
+                f"Use this angle if it fits naturally: {angle}.\n"
                 "Requirements:\n"
-                "- 6 to 12 words long\n"
+                "- 8 to 12 words long\n"
                 "- A specific topical question a real person would search for\n"
                 "- Specific enough to have clear answers in web results\n"
+                "- Include a concrete entity, location, policy, product, metric, "
+                "or stakeholder when it fits\n"
                 "- Plain natural language, no hashtags, no quoted phrases\n"
                 "- Do not mention search engines or tool names\n"
+                "- Do not default to social media, platform trends, or viral "
+                "content unless the topic explicitly requires it\n"
                 "- Do NOT include time phrases like 'today', 'this week', "
                 "'latest', or a specific year — a date filter is applied "
                 "separately, so the question text stays time-agnostic\n"
@@ -337,10 +465,16 @@ class QuestionsDataset:
         return (
             f'Generate ONE research question about "{topic}" whose best answer '
             f"benefits from combining these sources: {tools_str}.\n"
+            f"Use this angle if it fits naturally: {angle}.\n"
             "Requirements:\n"
-            "- 6 to 12 words long — keep it short and punchy\n"
+            "- 8 to 12 words long — keep it short and punchy\n"
             "- A natural topical question, not static trivia\n"
             "- Specific enough that a search will return relevant results\n"
+            "- The source names are evidence channels only; do not turn the "
+            "question into a social-media or platform-trend question just "
+            "because Twitter, Reddit, or YouTube is available\n"
+            "- Include a concrete entity, location, policy, product, metric, "
+            "or stakeholder when it fits\n"
             "- Plain natural language, no hashtags\n"
             "- Do not name the source tools in the question\n"
             "- Do NOT include time phrases like 'today', 'this week', "
@@ -351,19 +485,21 @@ class QuestionsDataset:
 
     async def generate_new_question_with_openai(self, selected_tools: list[str]) -> str:
         topic = self._random_topic()
-        prompt = self._build_prompt(topic, selected_tools)
+        angle = random.choice(QUESTION_ANGLES)
+        prompt = self._build_prompt(topic, selected_tools, angle)
 
         try:
             out = await call_openai(
                 messages=[{"role": "system", "content": prompt}],
                 model=QUESTION_MODEL,
+                temperature=QUESTION_TEMPERATURE,
             )
-            if not out:
-                return f"latest news about {topic}"
-            return out.strip().strip('"').strip("'")
+            return _clean_question(out) or self._fallback_question(
+                topic, selected_tools
+            )
         except Exception as e:
             bt.logging.error(f"generate_new_question_with_openai failed: {e}")
-            return f"latest news about {topic}"
+            return self._fallback_question(topic, selected_tools)
 
 
 class BasicQuestionsDataset:
@@ -408,7 +544,8 @@ class BasicQuestionsDataset:
 
     def __init__(self):
         self.faker = Faker()
-        self._topics = TOPICS
+        self._topic_sampler = _TopicSampler(TOPICS)
+        self._topics = self._topic_sampler.topics
 
     def generate_random_x_query(self) -> str:
         """
@@ -437,4 +574,4 @@ class BasicQuestionsDataset:
             kw = random.choice(self.POPULAR_CRYPTO_KEYWORDS)
             return f"#{kw}"
 
-        return random.choice(self._topics)
+        return self._topic_sampler.next_topic()

--- a/neurons/validators/clients/miner_response_logger.py
+++ b/neurons/validators/clients/miner_response_logger.py
@@ -9,9 +9,9 @@ import numpy as np
 from pydantic import BaseModel
 
 REWARD_COMPONENT_NAMES = {
-    "ai_search": ["twitter", "search", "summary"],
-    "x_search": ["twitter"],
-    "web_search": ["search"],
+    "ai_search": ["twitter", "search", "summary", "performance"],
+    "x_search": ["twitter", "performance"],
+    "web_search": ["search", "performance"],
 }
 _RESPONSE_PAYLOAD_EXCLUDED_KEYS = {"html_content", "html_text"}
 

--- a/neurons/validators/penalty/duplicate_results_penalty.py
+++ b/neurons/validators/penalty/duplicate_results_penalty.py
@@ -3,6 +3,7 @@ from desearch.protocol import (
     TwitterSearchSynapse,
     WebSearchSynapse,
 )
+from desearch.utils import format_text_for_match
 from neurons.validators.penalty.penalty import CheapPenaltyModel, PenaltyModelType
 from neurons.validators.utils.response_checks import (
     AI_SEARCH_RESULT_FIELDS,
@@ -11,16 +12,29 @@ from neurons.validators.utils.response_checks import (
 
 
 def _result_groups(response):
-    """Yield ``(items, dedup_key)`` for every result list to check."""
+    """Yield ``(items, dedup_keys, check_text)`` for every result list to check."""
     if isinstance(response, TwitterSearchSynapse):
-        yield response.results or [], "id"
+        yield response.results or [], ("id", "url"), True
     elif isinstance(response, WebSearchSynapse):
-        yield response.results or [], "link"
+        yield response.results or [], ("link", "url"), False
     elif isinstance(response, ScraperStreamingSynapse):
         if response.miner_tweets:
-            yield response.miner_tweets, "id"
+            yield response.miner_tweets, ("id", "url"), True
         for field in AI_SEARCH_RESULT_FIELDS:
-            yield getattr(response, field, []) or [], "link"
+            yield getattr(response, field, []) or [], ("link", "url"), False
+
+
+def _has_duplicate_text(items) -> bool:
+    seen: set[str] = set()
+    for item in items or []:
+        text = item.get("text") if isinstance(item, dict) else getattr(item, "text", "")
+        normalized = format_text_for_match(text or "").lower()
+        if not normalized:
+            continue
+        if normalized in seen:
+            return True
+        seen.add(normalized)
+    return False
 
 
 class DuplicateResultsPenaltyModel(CheapPenaltyModel):
@@ -30,7 +44,10 @@ class DuplicateResultsPenaltyModel(CheapPenaltyModel):
     name = PenaltyModelType.duplicate_results_penalty.value
 
     def penalty_for(self, response) -> float:
-        for items, key in _result_groups(response):
-            if first_duplicate_id(items, key=key) is not None:
+        for items, keys, check_text in _result_groups(response):
+            for key in keys:
+                if first_duplicate_id(items, key=key) is not None:
+                    return self.max_penalty
+            if check_text and _has_duplicate_text(items):
                 return self.max_penalty
         return 0.0

--- a/neurons/validators/proxy/uid_manager.py
+++ b/neurons/validators/proxy/uid_manager.py
@@ -6,10 +6,13 @@ from bittensor.core.metagraph import AsyncMetagraph
 
 from desearch.miner_config import SEARCH_TYPES
 from neurons.validators.scoring import miner_db
+from neurons.validators.scoring.constants import (
+    QUALITY_EXPONENT,
+    VOLUME_EXPONENT,
+)
 from neurons.validators.scoring.weights import EMISSION_CONTROL_HOTKEY
 
 QUALITY_FLOOR = 0.1
-QUALITY_EXPONENT = 2.0
 RAMP_EVIDENCE_VERIFIED = 2
 MIN_MIGRATION_POOL = 2
 
@@ -84,9 +87,10 @@ class UIDManager:
                     continue
                 if any_ramped:
                     quality_avg, verified = rows.get(uid, (0.0, 1))
-                    weights[uid] = max(
-                        quality_avg, QUALITY_FLOOR
-                    ) ** QUALITY_EXPONENT * max(verified, 1)
+                    weights[uid] = (
+                        max(quality_avg, QUALITY_FLOOR) ** QUALITY_EXPONENT
+                        * max(verified, 1) ** VOLUME_EXPONENT
+                    )
                 else:
                     weights[uid] = 1.0 if uid in migration_pool else 0.0
             self.weights_by_type[search_type] = weights

--- a/neurons/validators/reward/reward.py
+++ b/neurons/validators/reward/reward.py
@@ -247,54 +247,10 @@ class BaseRewardModel:
             original_rewards,
         )
 
-    def calculate_adjusted_score(
-        self,
-        links_count: int,
-        score: float,
-        duplicate_tweets_count: int = 0,
-        max_bonus: float = 0.2,
-        link_sensitivity: int = 9,
-        max_links_threshold: int = 10,
-        penalty_factor: float = 0.1,
-    ) -> float:
-        """
-        Calculate the combined score by first applying a bonus based on the number of links and then adjusting
-        the score based on the number of completion links with a softer penalty for having fewer than 10 links.
-        If the number of links exceeds the max_links_threshold, a penalty is applied.
-
-        Args:
-        - score (float): The original score ranging from 0.1 to 1.
-        - links_count (int): The number of links or completion links.
-        - max_bonus (float): The maximum bonus to add to the score for the link count scenario. Default is 0.2.
-        - link_sensitivity (int): Controls how quickly the bonus grows with the number of links. Higher values mean slower growth.
-        - max_links_threshold (int): The threshold for the maximum number of links before penalties apply.
-        - penalty_factor (float): The penalty applied for each link above the threshold.
-
-        Returns:
-        - float: The combined adjusted score considering the provided parameters.
-        """
-        # Calculate the bonus based on the number of links
-        bonus = max_bonus * (
-            1 - 1 / (1 + min(links_count, max_links_threshold) / link_sensitivity)
-        )
-        intermediate_score = min(1, score + bonus)
-
-        # Adjust the intermediate score based on the number of completion links
-        if links_count <= max_links_threshold:
-            # Using square root to soften the penalty for having fewer than max_links_threshold links
-            penalty_factor = (links_count / max_links_threshold) ** 0.5
-        else:
-            # Apply a penalty for each link over the threshold
-            excess_links = links_count - max_links_threshold
-            penalty_factor = max(0, 1 - excess_links * penalty_factor)
-
-        adjusted_score = intermediate_score * penalty_factor
-
-        if duplicate_tweets_count > 0:
-            penalty_score = duplicate_tweets_count * 0.05
-            adjusted_score = max(0, adjusted_score - penalty_score)
-
-        return adjusted_score
+    @staticmethod
+    def clamp_relevance_score(score: float) -> float:
+        """Keep relevance scores in reward range; penalties live elsewhere."""
+        return max(0, min(1, score))
 
     async def process_response_items_in_batches(
         self, responses, batch_size, process_function

--- a/neurons/validators/reward/search_content_relevance.py
+++ b/neurons/validators/reward/search_content_relevance.py
@@ -9,6 +9,11 @@ from desearch.protocol import ScraperStreamingSynapse
 from desearch.utils import clean_text
 from neurons.validators.apify.scrapingdog_scraper import scrape_links_with_retries
 from neurons.validators.base_validator import AbstractNeuron
+from neurons.validators.penalty.count_penalty import (
+    HACKER_NEWS_TOOL,
+    REDDIT_TOOL,
+    SEARCH_SUMMARY_TOOLS,
+)
 from neurons.validators.reward.reward_llm import RewardLLM
 from neurons.validators.utils.prompts import (
     SearchSummaryRelevancePrompt,
@@ -16,6 +21,12 @@ from neurons.validators.utils.prompts import (
 
 from .config import RewardModelType
 from .reward import BaseRewardEvent, BaseRewardModel, log_reward_aggregates
+
+WEB_TOOLS = frozenset((*SEARCH_SUMMARY_TOOLS, REDDIT_TOOL, HACKER_NEWS_TOOL))
+
+
+def response_uses_web_tools(response: ScraperStreamingSynapse) -> bool:
+    return bool(set(response.tools or []) & WEB_TOOLS)
 
 
 class WebSearchContentRelevanceModel(BaseRewardModel):
@@ -36,7 +47,7 @@ class WebSearchContentRelevanceModel(BaseRewardModel):
         self.scoring_type = scoring_type
 
     async def llm_process_validator_links(self, response: ScraperStreamingSynapse):
-        if not response.validator_links:
+        if not response_uses_web_tools(response) or not response.validator_links:
             return {}
 
         scoring_messages = []
@@ -84,6 +95,9 @@ class WebSearchContentRelevanceModel(BaseRewardModel):
         responses_random_links = [[] for _ in responses]
 
         for response, random_links in zip(responses, responses_random_links):
+            if not response_uses_web_tools(response):
+                continue
+
             # Extract random links from search results based on tools
             completion = self.get_successful_search_summary_completion(response)
 
@@ -159,6 +173,9 @@ class WebSearchContentRelevanceModel(BaseRewardModel):
 
     def check_response_random_link(self, response: ScraperStreamingSynapse):
         try:
+            if not response_uses_web_tools(response):
+                return 0
+
             completion = self.get_successful_search_summary_completion(
                 response=response
             )
@@ -291,6 +308,7 @@ class WebSearchContentRelevanceModel(BaseRewardModel):
             ):
                 reward_event = BaseRewardEvent()
                 reward_event.reward = 0
+                is_applicable = response_uses_web_tools(response)
 
                 response_scores = {}
                 total_score = 0
@@ -308,7 +326,9 @@ class WebSearchContentRelevanceModel(BaseRewardModel):
                     average_score = total_score / attempted_count
 
                     reward_event.reward = self.clamp_relevance_score(average_score)
-                missing_validator_links.append(1 if attempted_count == 0 else 0)
+                missing_validator_links.append(
+                    1 if is_applicable and attempted_count == 0 else 0
+                )
 
                 reward_event.reward = min(reward_event.reward * apify_score, 1)
                 reward_events.append(reward_event)

--- a/neurons/validators/reward/search_content_relevance.py
+++ b/neurons/validators/reward/search_content_relevance.py
@@ -295,8 +295,6 @@ class WebSearchContentRelevanceModel(BaseRewardModel):
                 response_scores = {}
                 total_score = 0
 
-                _, links_expected = response.get_search_results_by_tools()
-
                 for val_link in response.validator_links:
                     val_url = val_link.get("link")
                     if val_score_responses:
@@ -309,13 +307,7 @@ class WebSearchContentRelevanceModel(BaseRewardModel):
                 if attempted_count > 0 and total_score > 0:
                     average_score = total_score / attempted_count
 
-                    search_result_links, _ = response.get_links_from_search_results()
-
-                    reward_event.reward = self.calculate_adjusted_score(
-                        links_count=len(search_result_links),
-                        score=average_score,
-                        max_links_threshold=links_expected,
-                    )
+                    reward_event.reward = self.clamp_relevance_score(average_score)
                 missing_validator_links.append(1 if attempted_count == 0 else 0)
 
                 reward_event.reward = min(reward_event.reward * apify_score, 1)

--- a/neurons/validators/reward/twitter_content_relevance.py
+++ b/neurons/validators/reward/twitter_content_relevance.py
@@ -351,10 +351,6 @@ class TwitterContentRelevanceModel(BaseRewardModel):
 
                 unique_validator_tweets = list(unique_tweet_texts.values())
 
-                duplicate_tweets_count = len(response.validator_tweets) - len(
-                    unique_validator_tweets
-                )
-
                 response.validator_tweets = unique_validator_tweets
 
                 if len(response.validator_tweets):
@@ -375,12 +371,7 @@ class TwitterContentRelevanceModel(BaseRewardModel):
                             total_score / APIFY_LINK_SCRAPE_AMOUNT * apify_score
                         )
 
-                        reward_event.reward = self.calculate_adjusted_score(
-                            links_count=len(response.miner_tweets),
-                            score=average_score,
-                            duplicate_tweets_count=duplicate_tweets_count,
-                            max_links_threshold=response.count,
-                        )
+                        reward_event.reward = self.clamp_relevance_score(average_score)
                 else:
                     missing_validator_tweets.append(1)
                     reward_event.reward = 0

--- a/neurons/validators/reward/twitter_content_relevance.py
+++ b/neurons/validators/reward/twitter_content_relevance.py
@@ -8,7 +8,7 @@ from typing import List
 import bittensor as bt
 import pytz
 
-from desearch.protocol import ScraperStreamingSynapse
+from desearch.protocol import ScraperStreamingSynapse, TwitterScraperTweet
 from desearch.services.twitter_api_wrapper import TwitterAPIClient
 from desearch.services.twitter_utils import TwitterUtils
 from desearch.utils import (
@@ -54,6 +54,20 @@ class TwitterContentRelevanceModel(BaseRewardModel):
     def clean_text(self, text):
         return clean_text(text)
 
+    @staticmethod
+    def build_relevance_content(validator_tweet: TwitterScraperTweet) -> str:
+        """Tweet text plus any quoted tweet's text, so quote-driven relevance isn't lost."""
+        text = validator_tweet.text or ""
+
+        quote = validator_tweet.quote
+        quoted_text = (quote.text or "").strip() if quote else ""
+        if not quoted_text:
+            return text
+
+        handle = getattr(getattr(quote, "user", None), "username", None)
+        header = f"Quoted tweet (@{handle}):" if handle else "Quoted tweet:"
+        return f"{text}\n\n{header} {quoted_text}"
+
     async def llm_process_validator_tweets(self, response: ScraperStreamingSynapse):
         if not response.validator_tweets:
             return {}, 0.0
@@ -61,7 +75,7 @@ class TwitterContentRelevanceModel(BaseRewardModel):
         start_llm_time = time.time()
         scoring_messages = []
         for validator_tweet in response.validator_tweets:
-            val_text = validator_tweet.text
+            val_text = self.build_relevance_content(validator_tweet)
             val_tweet_id = validator_tweet.id
             result = self.get_scoring_text(
                 prompt=response.prompt,

--- a/neurons/validators/reward/twitter_content_relevance.py
+++ b/neurons/validators/reward/twitter_content_relevance.py
@@ -18,6 +18,7 @@ from desearch.utils import (
     scrape_tweets_with_retries,
 )
 from neurons.validators.base_validator import AbstractNeuron
+from neurons.validators.penalty.count_penalty import TWITTER_TOOL
 from neurons.validators.reward.reward_llm import RewardLLM
 from neurons.validators.utils.prompts import LinkContentPrompt
 
@@ -30,6 +31,10 @@ from .reward import (
 )
 
 APIFY_LINK_SCRAPE_AMOUNT = 3
+
+
+def response_uses_twitter_tool(response: ScraperStreamingSynapse) -> bool:
+    return TWITTER_TOOL in set(response.tools or [])
 
 
 class TwitterContentRelevanceModel(BaseRewardModel):
@@ -69,7 +74,7 @@ class TwitterContentRelevanceModel(BaseRewardModel):
         return f"{text}\n\n{header} {quoted_text}"
 
     async def llm_process_validator_tweets(self, response: ScraperStreamingSynapse):
-        if not response.validator_tweets:
+        if not response_uses_twitter_tool(response) or not response.validator_tweets:
             return {}, 0.0
 
         start_llm_time = time.time()
@@ -101,6 +106,9 @@ class TwitterContentRelevanceModel(BaseRewardModel):
             all_links = []
 
             for response, random_links in zip(responses, responses_random_links):
+                if not response_uses_twitter_tool(response):
+                    continue
+
                 if response.miner_tweets:
                     sample_tweets = random.sample(
                         response.miner_tweets,
@@ -118,6 +126,7 @@ class TwitterContentRelevanceModel(BaseRewardModel):
                     random_links.extend(sample_links)
 
             unique_links = list(set(all_links))
+
             if len(unique_links) == 0:
                 bt.logging.info("No unique links found to process.")
                 return default_val_score_responses
@@ -176,6 +185,9 @@ class TwitterContentRelevanceModel(BaseRewardModel):
 
     def check_tweet_content(self, response: ScraperStreamingSynapse):
         try:
+            if not response_uses_twitter_tool(response):
+                return 0
+
             tweet_score = 0
 
             completion = self.get_successful_twitter_completion(response=response)
@@ -338,6 +350,7 @@ class TwitterContentRelevanceModel(BaseRewardModel):
             ):
                 reward_event = BaseRewardEvent()
                 reward_event.reward = 0
+                is_applicable = response_uses_twitter_tool(response)
 
                 score_result = None
                 response_scores = {}
@@ -373,7 +386,7 @@ class TwitterContentRelevanceModel(BaseRewardModel):
 
                         reward_event.reward = self.clamp_relevance_score(average_score)
                 else:
-                    missing_validator_tweets.append(1)
+                    missing_validator_tweets.append(1 if is_applicable else 0)
                     reward_event.reward = 0
                 reward_events.append(reward_event)
                 grouped_val_score_responses.append(response_scores)

--- a/neurons/validators/scoring/capacity.py
+++ b/neurons/validators/scoring/capacity.py
@@ -6,17 +6,12 @@ from typing import Optional, Protocol
 import bittensor as bt
 
 from desearch.miner_config import SEARCH_TYPES
+from neurons.validators.scoring.constants import DEFAULT_PER_UID, QUALITY_THRESHOLDS
 from neurons.validators.scoring import miner_db
 
 QUALITY_EMA_ALPHA = 0.5
 
-DEFAULT_PER_UID = 1
 HARD_CAP_PER_UID = 100
-QUALITY_THRESHOLDS: dict[str, float] = {
-    "ai_search": 0.50,
-    "x_search": 0.60,
-    "web_search": 0.60,
-}
 RAMP_FRACTION = 0.10
 DECAY_FRACTION = 0.10
 

--- a/neurons/validators/scoring/constants.py
+++ b/neurons/validators/scoring/constants.py
@@ -1,0 +1,18 @@
+SEARCH_TYPE_WEIGHTS = {
+    "ai_search": 0.80,
+    "x_search": 0.10,
+    "web_search": 0.10,
+}
+
+QUALITY_THRESHOLDS: dict[str, float] = {
+    "ai_search": 0.50,
+    "x_search": 0.60,
+    "web_search": 0.60,
+}
+
+QUALITY_EXPONENT = 3.0
+VOLUME_EXPONENT = 2.0
+COVERAGE_EXPONENT = 2.0
+MIN_VOLUME_RATIO = 0.70
+
+DEFAULT_PER_UID = 1

--- a/neurons/validators/scoring/query_scheduler.py
+++ b/neurons/validators/scoring/query_scheduler.py
@@ -10,22 +10,20 @@ import bittensor as bt
 import numpy as np
 
 from neurons.validators.scoring import capacity, miner_db
+from neurons.validators.scoring.constants import (
+    COVERAGE_EXPONENT,
+    DEFAULT_PER_UID,
+    MIN_VOLUME_RATIO,
+    QUALITY_EXPONENT,
+    QUALITY_THRESHOLDS,
+    SEARCH_TYPE_WEIGHTS,
+    VOLUME_EXPONENT,
+)
 from neurons.validators.scoring.scoring_store import SEARCH_TYPES, ScoringStore
 from neurons.validators.scoring.synthetic_query_generator import SyntheticQueryGenerator
 
-SEARCH_TYPE_WEIGHTS = {
-    "ai_search": 0.80,
-    "x_search": 0.10,
-    "web_search": 0.10,
-}
-
 ORGANIC_VALUE_MULTIPLIER = 3
 ORGANIC_DEEP_CAP_PER_TYPE = 100
-
-QUALITY_EXPONENT = 2.0
-VOLUME_EXPONENT = 1.2
-COVERAGE_EXPONENT = 2.0
-MIN_VOLUME_RATIO = 0.50
 
 BATCH_FRACTION = 0.50
 BATCH_INTERVAL_SECONDS = 3
@@ -53,7 +51,7 @@ def combine_superlinear_scores(
 
         served: dict[str, float] = {}
         for t, (q, v) in qv.items():
-            if max_v == 0 or q < capacity.QUALITY_THRESHOLDS[t]:
+            if max_v == 0 or q < QUALITY_THRESHOLDS[t]:
                 served[t] = 0.0
             else:
                 served[t] = min(1.0, (v / max_v) / MIN_VOLUME_RATIO)
@@ -409,7 +407,7 @@ class QueryScheduler:
                 search_type=search_type,
                 quality=quality,
                 window_start=window_start,
-                allocated=allocations.get(uid, capacity.DEFAULT_PER_UID),
+                allocated=allocations.get(uid, DEFAULT_PER_UID),
             )
         return uid_results
 
@@ -554,7 +552,7 @@ class QueryScheduler:
                 for st in SEARCH_TYPES:
                     rows = await miner_db.get_allocation_state(st)
                     allocations_by_type[st] = {
-                        uid: rows.get(uid, (0.0, 0, capacity.DEFAULT_PER_UID))[2]
+                        uid: rows.get(uid, (0.0, 0, DEFAULT_PER_UID))[2]
                         for uid in available_uids
                     }
 

--- a/neurons/validators/scoring/query_scheduler.py
+++ b/neurons/validators/scoring/query_scheduler.py
@@ -1,4 +1,5 @@
 import asyncio
+import math
 import random
 import time
 from collections import defaultdict
@@ -26,9 +27,9 @@ VOLUME_EXPONENT = 1.2
 COVERAGE_EXPONENT = 2.0
 MIN_VOLUME_RATIO = 0.50
 
-BATCH_SIZE = 20
+BATCH_FRACTION = 0.50
 BATCH_INTERVAL_SECONDS = 3
-GROUP_SIZE = 5
+GROUP_SIZE = 2
 
 DEEP_SAMPLE_RATE = 0.20
 DEEP_SAMPLE_FLOOR = 1
@@ -84,7 +85,7 @@ class QueryScheduler:
       1. Batch-generate all queries for every active UID via SyntheticQueryGenerator.
          Epoch-level params (tools, date_filter) are shared; only question text varies.
          Each miner gets N queries per search type where N = verified concurrency.
-      2. Dispatch each query at its random fire time spread over ~55 minutes.
+      2. Dispatch shuffled UID groups in 50% per-UID bursts.
       3. Save the miner's response in ScoringStore.
       4. On hour boundary -> score the previous hour's responses and update capacity.
 
@@ -160,8 +161,7 @@ class QueryScheduler:
         items: list,
         time_range_start: datetime,
     ) -> None:
-        """Dispatch AI, X, Web sequentially. Each phase walks sorted UIDs in
-        groups of GROUP_SIZE; UIDs within a group run concurrently."""
+        """Dispatch each type through shuffled UID groups."""
         for search_type in SEARCH_TYPES:
             if self._current_hour_start() != time_range_start:
                 return
@@ -171,17 +171,19 @@ class QueryScheduler:
                 if item["search_type"] == search_type:
                     grouped[item["uid"]].append(item)
 
-            sorted_uids = sorted(grouped)
+            shuffled_uids = sorted(grouped)
+            random.shuffle(shuffled_uids)
             bt.logging.info(
                 f"[QueryScheduler] Phase {search_type}: "
                 f"{sum(len(v) for v in grouped.values())} queries "
-                f"across {len(sorted_uids)} UIDs in groups of {GROUP_SIZE}"
+                f"across {len(shuffled_uids)} shuffled UIDs "
+                f"in groups of {GROUP_SIZE}"
             )
 
-            for start in range(0, len(sorted_uids), GROUP_SIZE):
+            for start in range(0, len(shuffled_uids), GROUP_SIZE):
                 if self._current_hour_start() != time_range_start:
                     return
-                group = sorted_uids[start : start + GROUP_SIZE]
+                group = shuffled_uids[start : start + GROUP_SIZE]
                 await asyncio.gather(
                     *[
                         self._dispatch_uid(
@@ -192,6 +194,10 @@ class QueryScheduler:
                     return_exceptions=True,
                 )
 
+    @staticmethod
+    def _batch_size_for_uid(uid_items: list) -> int:
+        return max(1, math.ceil(len(uid_items) * BATCH_FRACTION))
+
     async def _dispatch_uid(
         self,
         uid: int,
@@ -199,8 +205,10 @@ class QueryScheduler:
         uid_items: list,
         time_range_start: datetime,
     ) -> None:
+        batch_size = self._batch_size_for_uid(uid_items)
         batches = [
-            uid_items[i : i + BATCH_SIZE] for i in range(0, len(uid_items), BATCH_SIZE)
+            uid_items[i : i + batch_size]
+            for i in range(0, len(uid_items), batch_size)
         ]
 
         for batch_idx, batch in enumerate(batches):

--- a/neurons/validators/scoring/synthetic_query_generator.py
+++ b/neurons/validators/scoring/synthetic_query_generator.py
@@ -10,6 +10,9 @@ from desearch.dataset.date_filters import random_date_filters
 # Tool combinations for AI search scoring — weighted by frequency.
 # Chosen once per epoch so every miner is evaluated on the same tools.
 AI_SEARCH_TOOL_SETS = [
+    ["Twitter Search"],
+    ["Twitter Search"],
+    ["Twitter Search"],
     ["Twitter Search", "Reddit Search"],
     ["Twitter Search", "Web Search"],
     ["Twitter Search", "Web Search"],

--- a/neurons/validators/scrapers/advanced_scraper_validator.py
+++ b/neurons/validators/scrapers/advanced_scraper_validator.py
@@ -22,7 +22,13 @@ from neurons.validators.clients.miner_response_logger import (
     build_log_entry,
     submit_logs_best_effort,
 )
-from neurons.validators.penalty.count_penalty import CountPenaltyModel
+from neurons.validators.penalty.count_penalty import (
+    CountPenaltyModel,
+    HACKER_NEWS_TOOL,
+    REDDIT_TOOL,
+    SEARCH_SUMMARY_TOOLS,
+    TWITTER_TOOL,
+)
 from neurons.validators.penalty.date_range_penalty import DateRangePenaltyModel
 from neurons.validators.penalty.duplicate_results_penalty import (
     DuplicateResultsPenaltyModel,
@@ -50,17 +56,7 @@ from neurons.validators.reward.twitter_content_relevance import (
 from neurons.validators.scoring import capacity
 from neurons.validators.scrapers.base_scraper_validator import BaseScraperValidator
 
-TWITTER_TOOL = "Twitter Search"
-WEB_TOOLS = frozenset(
-    [
-        "Web Search",
-        "Wikipedia Search",
-        "Youtube Search",
-        "ArXiv Search",
-        "Reddit Search",
-        "Hacker News Search",
-    ]
-)
+WEB_TOOLS = frozenset((*SEARCH_SUMMARY_TOOLS, REDDIT_TOOL, HACKER_NEWS_TOOL))
 
 
 class AdvancedScraperValidator(BaseScraperValidator):
@@ -74,8 +70,8 @@ class AdvancedScraperValidator(BaseScraperValidator):
         self.date_filter = "qdr:w"  # Past week
 
         self.twitter_content_weight = 0.30
-        self.web_search_weight = 0.25
-        self.summary_relevance_weight = 0.25
+        self.web_search_weight = 0.30
+        self.summary_relevance_weight = 0.20
         self.performance_weight = 0.20
 
         self.reward_llm = RewardLLM(neuron.config.neuron.scoring_model)
@@ -144,7 +140,7 @@ class AdvancedScraperValidator(BaseScraperValidator):
         — so the unused branch gets weight 0 rather than the old `reward = 1.0`
         free pass.
         """
-        tools = set(response.tools)
+        tools = set(response.tools or [])
         has_twitter = TWITTER_TOOL in tools
         has_web = bool(tools & WEB_TOOLS)
         content = self.twitter_content_weight + self.web_search_weight

--- a/tests/validators/penalty/test_duplicate_results_penalty.py
+++ b/tests/validators/penalty/test_duplicate_results_penalty.py
@@ -31,6 +31,28 @@ class DuplicateResultsPenaltyTestCase(unittest.IsolatedAsyncioTestCase):
         penalties = await self.model.calculate_penalties([response])
         self.assertEqual(penalties.tolist(), [1.0])
 
+    async def test_twitter_duplicate_urls(self):
+        response = TwitterSearchSynapse(
+            query="x",
+            results=[
+                {"id": "1", "url": "https://x.com/a/status/1"},
+                {"id": "2", "url": "https://x.com/a/status/1"},
+            ],
+        )
+        penalties = await self.model.calculate_penalties([response])
+        self.assertEqual(penalties.tolist(), [1.0])
+
+    async def test_twitter_duplicate_texts(self):
+        response = TwitterSearchSynapse(
+            query="x",
+            results=[
+                {"id": "1", "url": "https://x.com/a/status/1", "text": "Same tweet"},
+                {"id": "2", "url": "https://x.com/b/status/2", "text": " same  tweet "},
+            ],
+        )
+        penalties = await self.model.calculate_penalties([response])
+        self.assertEqual(penalties.tolist(), [1.0])
+
     async def test_web_duplicate_links(self):
         response = WebSearchSynapse(
             query="x",
@@ -39,6 +61,32 @@ class DuplicateResultsPenaltyTestCase(unittest.IsolatedAsyncioTestCase):
                 {"link": "https://a"},
                 {"link": "https://b"},
                 {"link": "https://a"},
+            ],
+        )
+        penalties = await self.model.calculate_penalties([response])
+        self.assertEqual(penalties.tolist(), [1.0])
+
+    async def test_single_duplicate_zeroes_response_multiplier(self):
+        response = WebSearchSynapse(
+            query="x",
+            num=10,
+            results=[
+                {"link": "https://a"},
+                {"link": "https://b"},
+                {"link": "https://a"},
+            ],
+        )
+        _, _, applied = await self.model.apply_penalties([response], uids=[0])
+        self.assertEqual(applied.tolist(), [0.0])
+
+    async def test_web_duplicate_urls(self):
+        response = WebSearchSynapse(
+            query="x",
+            num=10,
+            results=[
+                {"url": "https://a"},
+                {"url": "https://b"},
+                {"url": "https://a"},
             ],
         )
         penalties = await self.model.calculate_penalties([response])
@@ -57,6 +105,28 @@ class DuplicateResultsPenaltyTestCase(unittest.IsolatedAsyncioTestCase):
         response = ScraperStreamingSynapse(
             prompt="x",
             miner_tweets=[{"id": "1"}, {"id": "1"}],
+        )
+        penalties = await self.model.calculate_penalties([response])
+        self.assertEqual(penalties.tolist(), [1.0])
+
+    async def test_ai_dup_in_miner_tweet_urls(self):
+        response = ScraperStreamingSynapse(
+            prompt="x",
+            miner_tweets=[
+                {"id": "1", "url": "https://x.com/a/status/1"},
+                {"id": "2", "url": "https://x.com/a/status/1"},
+            ],
+        )
+        penalties = await self.model.calculate_penalties([response])
+        self.assertEqual(penalties.tolist(), [1.0])
+
+    async def test_ai_dup_in_miner_tweet_texts(self):
+        response = ScraperStreamingSynapse(
+            prompt="x",
+            miner_tweets=[
+                {"id": "1", "url": "https://x.com/a/status/1", "text": "Same tweet"},
+                {"id": "2", "url": "https://x.com/b/status/2", "text": "same tweet"},
+            ],
         )
         penalties = await self.model.calculate_penalties([response])
         self.assertEqual(penalties.tolist(), [1.0])

--- a/tests/validators/proxy/test_uid_manager.py
+++ b/tests/validators/proxy/test_uid_manager.py
@@ -1,0 +1,69 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import numpy as np
+import pytest
+
+from desearch.miner_config import SEARCH_TYPES
+from neurons.validators.proxy import uid_manager
+from neurons.validators.proxy.uid_manager import UIDManager
+from neurons.validators.scoring.constants import (
+    QUALITY_EXPONENT,
+    VOLUME_EXPONENT,
+)
+
+
+def _metagraph():
+    return SimpleNamespace(
+        I=np.array([0.0, 0.3, 0.2, 0.1]),
+        neurons=[SimpleNamespace(uid=uid, hotkey=f"h{uid}") for uid in range(4)],
+    )
+
+
+async def test_ramped_organic_routing_is_superlinear_in_verified_capacity(
+    monkeypatch,
+):
+    rows = {1: (0.7, 100), 2: (0.7, 50), 3: (0.7, 50)}
+    monkeypatch.setattr(
+        uid_manager.miner_db,
+        "get_all_concurrency_data",
+        AsyncMock(return_value=rows),
+    )
+    monkeypatch.setattr(
+        uid_manager.miner_db,
+        "get_unreachable_uids",
+        AsyncMock(return_value=set()),
+    )
+
+    manager = UIDManager()
+    await manager.resync([1, 2, 3], _metagraph())
+
+    for search_type in SEARCH_TYPES:
+        weights = manager.weights_by_type[search_type]
+        assert weights[1] > weights[2] + weights[3]
+        assert weights[1] / (weights[2] + weights[3]) == pytest.approx(
+            2 ** (VOLUME_EXPONENT - 1)
+        )
+
+
+async def test_ramped_organic_routing_uses_quality_exponent(monkeypatch):
+    rows = {1: (0.8, 10), 2: (0.7, 10)}
+    monkeypatch.setattr(
+        uid_manager.miner_db,
+        "get_all_concurrency_data",
+        AsyncMock(return_value=rows),
+    )
+    monkeypatch.setattr(
+        uid_manager.miner_db,
+        "get_unreachable_uids",
+        AsyncMock(return_value=set()),
+    )
+
+    manager = UIDManager()
+    await manager.resync([1, 2], _metagraph())
+
+    for search_type in SEARCH_TYPES:
+        weights = manager.weights_by_type[search_type]
+        assert weights[1] / weights[2] == pytest.approx(
+            (0.8 / 0.7) ** QUALITY_EXPONENT
+        )

--- a/tests/validators/reward/test_content_relevance_score_clamp.py
+++ b/tests/validators/reward/test_content_relevance_score_clamp.py
@@ -1,0 +1,24 @@
+import unittest
+
+from neurons.validators.reward.twitter_content_relevance import (
+    TwitterContentRelevanceModel,
+)
+
+
+class ContentRelevanceScoreClampTestCase(unittest.TestCase):
+    def setUp(self):
+        self.model = TwitterContentRelevanceModel.__new__(TwitterContentRelevanceModel)
+
+    def test_relevance_passes_through_without_link_bonus(self):
+        low_relevance = 1 / 3
+
+        self.assertEqual(self.model.clamp_relevance_score(low_relevance), low_relevance)
+        self.assertEqual(self.model.clamp_relevance_score(0.75), 0.75)
+
+    def test_relevance_is_clamped_to_reward_range(self):
+        self.assertEqual(self.model.clamp_relevance_score(1.25), 1)
+        self.assertEqual(self.model.clamp_relevance_score(-0.25), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validators/reward/test_twitter_content_relevance.py
+++ b/tests/validators/reward/test_twitter_content_relevance.py
@@ -1,0 +1,170 @@
+import unittest
+from unittest.mock import AsyncMock
+
+from desearch.protocol import (
+    ScraperStreamingSynapse,
+    TwitterScraperTweet,
+    TwitterScraperUser,
+)
+from neurons.validators.reward.twitter_content_relevance import (
+    TwitterContentRelevanceModel,
+)
+from tests_data.tweets.tweet1 import tweet1
+from tests_data.tweets.tweet2 import tweet2
+
+
+def make_tweet(
+    text: str,
+    quote_text: str | None = None,
+    quote_username: str | None = None,
+) -> TwitterScraperTweet:
+    quote = None
+    if quote_text is not None:
+        quote = TwitterScraperTweet(
+            user=(
+                TwitterScraperUser(id="q-user", username=quote_username)
+                if quote_username
+                else None
+            ),
+            id="quoted-id",
+            text=quote_text,
+            reply_count=0,
+            retweet_count=0,
+            like_count=0,
+            quote_count=0,
+            bookmark_count=0,
+            url="https://x.com/quoted/status/1",
+            created_at="Sun Feb 02 02:39:05 +0000 2025",
+            is_quote_tweet=False,
+            is_retweet=False,
+        )
+
+    return TwitterScraperTweet(
+        user=TwitterScraperUser(id="user", username="author"),
+        id="main-id",
+        text=text,
+        reply_count=0,
+        retweet_count=0,
+        like_count=0,
+        quote_count=0,
+        bookmark_count=0,
+        url="https://x.com/author/status/2",
+        created_at="Sun Feb 09 08:40:53 +0000 2025",
+        is_quote_tweet=quote is not None,
+        is_retweet=False,
+        quote=quote,
+    )
+
+
+class BuildRelevanceContentTestCase(unittest.TestCase):
+    def test_quote_tweet_includes_quoted_text_and_handle(self):
+        tweet = make_tweet(
+            "Big news today",
+            quote_text="The original announcement about widgets",
+            quote_username="OriginalAuthor",
+        )
+
+        content = TwitterContentRelevanceModel.build_relevance_content(tweet)
+
+        self.assertIn("Big news today", content)
+        self.assertIn("The original announcement about widgets", content)
+        self.assertIn("Quoted tweet (@OriginalAuthor):", content)
+
+    def test_quote_without_username_uses_plain_label(self):
+        tweet = make_tweet(
+            "Commentary",
+            quote_text="Quoted body text",
+            quote_username=None,
+        )
+
+        content = TwitterContentRelevanceModel.build_relevance_content(tweet)
+
+        self.assertIn("Quoted tweet: Quoted body text", content)
+        self.assertNotIn("@", content)
+
+    def test_non_quote_tweet_unchanged(self):
+        tweet = make_tweet("Standalone tweet text", quote_text=None)
+
+        content = TwitterContentRelevanceModel.build_relevance_content(tweet)
+
+        self.assertEqual(content, "Standalone tweet text")
+        self.assertNotIn("Quoted tweet", content)
+
+    def test_empty_quote_text_is_ignored(self):
+        tweet = make_tweet("Has empty quote", quote_text="   ", quote_username="x")
+
+        content = TwitterContentRelevanceModel.build_relevance_content(tweet)
+
+        self.assertEqual(content, "Has empty quote")
+        self.assertNotIn("Quoted tweet", content)
+
+    def test_none_quote_is_handled(self):
+        tweet = make_tweet("No quote field", quote_text=None)
+        tweet.quote = None
+
+        content = TwitterContentRelevanceModel.build_relevance_content(tweet)
+
+        self.assertEqual(content, "No quote field")
+
+    def test_real_fixture_non_quote(self):
+        tweet = TwitterScraperTweet(**tweet1)
+
+        content = TwitterContentRelevanceModel.build_relevance_content(tweet)
+
+        self.assertEqual(content, tweet1["text"])
+
+    def test_real_fixture_with_quote(self):
+        tweet = TwitterScraperTweet(**tweet2)
+
+        content = TwitterContentRelevanceModel.build_relevance_content(tweet)
+
+        self.assertIn(tweet2["text"], content)
+        self.assertIn(tweet2["quote"]["text"], content)
+        self.assertIn(f"@{tweet2['quote']['user']['username']}", content)
+
+
+class LlmProcessValidatorTweetsTestCase(unittest.IsolatedAsyncioTestCase):
+    def _model_with_mock_llm(self) -> TwitterContentRelevanceModel:
+        model = TwitterContentRelevanceModel.__new__(TwitterContentRelevanceModel)
+        model.reward_llm = AsyncMock()
+        model.reward_llm.llm_processing = AsyncMock(return_value={})
+        return model
+
+    async def test_scoring_messages_carry_quoted_context(self):
+        model = self._model_with_mock_llm()
+        response = ScraperStreamingSynapse(
+            prompt="What is happening with widgets?",
+            validator_tweets=[
+                make_tweet(
+                    "See this",
+                    quote_text="Detailed widget update from the source",
+                    quote_username="SourceAcct",
+                )
+            ],
+            tools=["Twitter Search"],
+        )
+
+        await model.llm_process_validator_tweets(response)
+
+        model.reward_llm.llm_processing.assert_awaited_once()
+        scoring_messages = model.reward_llm.llm_processing.call_args.args[0]
+        user_content = scoring_messages[0]["main-id"][1]["content"]
+        self.assertIn("widget update", user_content)
+
+    async def test_scoring_messages_non_quote_have_no_quote_marker(self):
+        model = self._model_with_mock_llm()
+        response = ScraperStreamingSynapse(
+            prompt="Tell me about widgets",
+            validator_tweets=[make_tweet("Plain standalone widget tweet")],
+            tools=["Twitter Search"],
+        )
+
+        await model.llm_process_validator_tweets(response)
+
+        scoring_messages = model.reward_llm.llm_processing.call_args.args[0]
+        user_content = scoring_messages[0]["main-id"][1]["content"]
+        self.assertNotIn("Quoted tweet", user_content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/validators/test_capacity.py
+++ b/tests/validators/test_capacity.py
@@ -55,7 +55,10 @@ def test_declared_below_default_clamps():
 
 
 def test_gate_passes_when_all_above_thresholds():
-    ema = {"ai_search": 0.46, "x_search": 0.61, "web_search": 0.61}
+    ema = {
+        search_type: threshold + 0.01
+        for search_type, threshold in QUALITY_THRESHOLDS.items()
+    }
     declared = {"ai_search": 100, "x_search": 100, "web_search": 100}
     assert passes_combined_gate(ema, declared) is True
 

--- a/tests/validators/test_miner_response_logging.py
+++ b/tests/validators/test_miner_response_logging.py
@@ -4,7 +4,11 @@ from unittest.mock import AsyncMock, patch
 import numpy as np
 import pytest
 
-from neurons.validators.clients.miner_response_logger import build_log_entry, submit_logs
+from neurons.validators.clients.miner_response_logger import (
+    build_log_entry,
+    build_reward_payload,
+    submit_logs,
+)
 from neurons.validators.scrapers.advanced_scraper_validator import AdvancedScraperValidator
 from neurons.validators.scrapers.web_scraper_validator import WebScraperValidator
 from neurons.validators.scrapers.x_scraper_validator import XScraperValidator
@@ -48,11 +52,11 @@ async def test_x_search_logs_selected_uid():
 
     with (
         patch(
-            "neurons.validators.x_scraper_validator.build_log_entry",
+            "neurons.validators.scrapers.x_scraper_validator.build_log_entry",
             return_value={"ok": True},
         ) as build_log_entry,
         patch(
-            "neurons.validators.x_scraper_validator.submit_logs_best_effort"
+            "neurons.validators.scrapers.x_scraper_validator.submit_logs_best_effort"
         ) as submit_logs_best_effort,
     ):
         items = [item async for item in validator.x_search({"query": "bittensor"})]
@@ -78,11 +82,11 @@ async def test_web_organic_logs_selected_uid():
 
     with (
         patch(
-            "neurons.validators.web_scraper_validator.build_log_entry",
+            "neurons.validators.scrapers.web_scraper_validator.build_log_entry",
             return_value={"ok": True},
         ) as build_log_entry,
         patch(
-            "neurons.validators.web_scraper_validator.submit_logs_best_effort"
+            "neurons.validators.scrapers.web_scraper_validator.submit_logs_best_effort"
         ) as submit_logs_best_effort,
     ):
         items = [item async for item in validator.organic({"query": "tao"})]
@@ -117,18 +121,21 @@ async def test_ai_organic_logs_after_stream_finishes():
 
     with (
         patch(
-            "neurons.validators.advanced_scraper_validator.build_log_entry",
+            "neurons.validators.scrapers.advanced_scraper_validator.build_log_entry",
             return_value={"ok": True},
         ) as build_log_entry,
         patch(
-            "neurons.validators.advanced_scraper_validator.submit_logs_best_effort"
+            "neurons.validators.scrapers.advanced_scraper_validator.submit_logs_best_effort"
         ) as submit_logs_best_effort,
+        patch(
+            "neurons.validators.scrapers.advanced_scraper_validator.bt.Synapse",
+            SimpleNamespace,
+        ),
     ):
         chunks = [
             item
             async for item in validator.organic(
                 {"content": "hello", "tools": ["Web Search"]},
-                uid=55,
             )
         ]
 
@@ -179,6 +186,43 @@ def test_build_log_entry_excludes_html_fields_from_response_payload():
     assert response.validator_links[0]["html_text"] == "big payload"
 
 
+@pytest.mark.parametrize(
+    ("search_type", "component_names"),
+    [
+        ("ai_search", ["twitter", "search", "summary", "performance"]),
+        ("x_search", ["twitter", "performance"]),
+        ("web_search", ["search", "performance"]),
+    ],
+)
+def test_build_reward_payload_includes_performance_component(
+    search_type, component_names
+):
+    rewards = [
+        np.array([idx / 10], dtype=np.float32)
+        for idx, _ in enumerate(component_names, start=1)
+    ]
+
+    payload = build_reward_payload(
+        search_type=search_type,
+        response_count=1,
+        index=0,
+        uid=42,
+        total_reward=0.5,
+        all_rewards=rewards,
+        all_original_rewards=[reward.tolist() for reward in rewards],
+        validator_scores=[{} for _ in rewards],
+        event={},
+    )
+
+    assert list(payload["components"]) == component_names
+    assert payload["components"]["performance"] == pytest.approx(
+        len(component_names) / 10
+    )
+    assert payload["original_components"]["performance"] == pytest.approx(
+        len(component_names) / 10
+    )
+
+
 @pytest.mark.asyncio
 async def test_x_post_by_id_logs_organic():
     validator = object.__new__(XScraperValidator)
@@ -200,11 +244,11 @@ async def test_x_post_by_id_logs_organic():
 
     with (
         patch(
-            "neurons.validators.x_scraper_validator.build_log_entry",
+            "neurons.validators.scrapers.x_scraper_validator.build_log_entry",
             return_value={"ok": True},
         ) as build_log_entry,
         patch(
-            "neurons.validators.x_scraper_validator.submit_logs_best_effort"
+            "neurons.validators.scrapers.x_scraper_validator.submit_logs_best_effort"
         ) as submit_logs_best_effort,
     ):
         results = await validator.x_post_by_id("123")
@@ -235,11 +279,11 @@ async def test_x_posts_by_urls_logs_organic():
 
     with (
         patch(
-            "neurons.validators.x_scraper_validator.build_log_entry",
+            "neurons.validators.scrapers.x_scraper_validator.build_log_entry",
             return_value={"ok": True},
         ) as build_log_entry,
         patch(
-            "neurons.validators.x_scraper_validator.submit_logs_best_effort"
+            "neurons.validators.scrapers.x_scraper_validator.submit_logs_best_effort"
         ) as submit_logs_best_effort,
     ):
         results = await validator.x_posts_by_urls(

--- a/tests/validators/test_query_scheduler.py
+++ b/tests/validators/test_query_scheduler.py
@@ -6,13 +6,15 @@ from unittest.mock import AsyncMock
 import pytest
 
 import neurons.validators.scoring.query_scheduler as query_scheduler
-from neurons.validators.scoring.capacity import QUALITY_THRESHOLDS
-from neurons.validators.scoring.query_scheduler import (
+from neurons.validators.scoring.constants import (
     COVERAGE_EXPONENT,
     MIN_VOLUME_RATIO,
     QUALITY_EXPONENT,
+    QUALITY_THRESHOLDS,
     SEARCH_TYPE_WEIGHTS,
     VOLUME_EXPONENT,
+)
+from neurons.validators.scoring.query_scheduler import (
     QueryScheduler,
     combine_superlinear_scores,
 )
@@ -45,11 +47,11 @@ def test_combine_below_floor_clamps_to_zero():
     assert out[1] == 0.0
 
 
-def test_combine_volume_is_mildly_superlinear():
-    """v=100 outearns v=50 by 2^1.2 ≈ 2.30× (consolidation bonus)."""
+def test_combine_volume_is_quadratic():
+    """v=100 outearns v=50 by 2^2 = 4× (strong consolidation bonus)."""
     big = combine_superlinear_scores(_uniform(0.6, 100, uid=1))
     small = combine_superlinear_scores(_uniform(0.6, 50, uid=2))
-    assert big[1] / small[2] == pytest.approx(2**1.2, rel=0.001)
+    assert big[1] / small[2] == pytest.approx(2**VOLUME_EXPONENT, rel=0.001)
 
 
 def test_combine_solo_beats_same_quality_split():
@@ -63,7 +65,9 @@ def test_combine_solo_beats_same_quality_split():
         }
     )
     assert solo[1] > split[2] + split[3]
-    assert solo[1] / (split[2] + split[3]) == pytest.approx(2**0.2, rel=0.001)
+    assert solo[1] / (split[2] + split[3]) == pytest.approx(
+        2 ** (VOLUME_EXPONENT - 1), rel=0.001
+    )
 
 
 def test_combine_split_uids_lose_to_higher_quality_solo():

--- a/tests/validators/test_query_scheduler.py
+++ b/tests/validators/test_query_scheduler.py
@@ -1,9 +1,11 @@
+import asyncio
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
+import neurons.validators.scoring.query_scheduler as query_scheduler
 from neurons.validators.scoring.capacity import QUALITY_THRESHOLDS
 from neurons.validators.scoring.query_scheduler import (
     COVERAGE_EXPONENT,
@@ -264,3 +266,78 @@ async def test_score_epoch_extracts_prompts_from_responses_and_passes_epoch_star
     kwargs = validator.compute_rewards_and_penalties.await_args.kwargs
     assert kwargs["scoring_epoch_start"] == epoch_start
     assert kwargs["prompts"] == ["what is bittensor", "what is tao"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_epoch_shuffles_uids_before_grouping(monkeypatch):
+    epoch_start = datetime(2026, 3, 14, 10, 0, tzinfo=timezone.utc)
+    scheduler = QueryScheduler(
+        neuron=SimpleNamespace(),
+        generator=SimpleNamespace(),
+        scoring_store=SimpleNamespace(),
+        validators={},
+    )
+
+    shuffled_inputs = []
+
+    def reverse_shuffle(uids):
+        shuffled_inputs.append(list(uids))
+        uids.reverse()
+
+    dispatched_uids = []
+
+    async def dispatch_uid(uid, search_type, uid_items, time_range_start):
+        dispatched_uids.append(uid)
+
+    scheduler._dispatch_uid = dispatch_uid
+    monkeypatch.setattr(
+        QueryScheduler, "_current_hour_start", staticmethod(lambda: epoch_start)
+    )
+    monkeypatch.setattr(query_scheduler.random, "shuffle", reverse_shuffle)
+    monkeypatch.setattr(query_scheduler, "GROUP_SIZE", 2)
+
+    items = [
+        {"uid": uid, "search_type": "ai_search", "query": {"query": str(uid)}}
+        for uid in [3, 1, 4, 2]
+    ]
+
+    await scheduler._dispatch_epoch(items, epoch_start)
+
+    assert [1, 2, 3, 4] in shuffled_inputs
+    assert dispatched_uids[:4] == [4, 3, 2, 1]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_uid_sends_half_allocation_per_batch(monkeypatch):
+    epoch_start = datetime(2026, 3, 14, 10, 0, tzinfo=timezone.utc)
+    scheduler = QueryScheduler(
+        neuron=SimpleNamespace(),
+        generator=SimpleNamespace(),
+        scoring_store=SimpleNamespace(),
+        validators={},
+    )
+
+    active = 0
+    max_active = 0
+    total_sent = 0
+
+    async def send_and_save(search_type, uid, query, time_range_start):
+        nonlocal active, max_active, total_sent
+        active += 1
+        total_sent += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0)
+        active -= 1
+
+    scheduler._send_and_save = send_and_save
+    monkeypatch.setattr(
+        QueryScheduler, "_current_hour_start", staticmethod(lambda: epoch_start)
+    )
+    monkeypatch.setattr(query_scheduler, "BATCH_INTERVAL_SECONDS", 0)
+
+    uid_items = [{"query": {"query": str(i)}} for i in range(100)]
+
+    await scheduler._dispatch_uid(7, "ai_search", uid_items, epoch_start)
+
+    assert total_sent == 100
+    assert max_active == 50

--- a/utility-api/app/domains/miners/client.py
+++ b/utility-api/app/domains/miners/client.py
@@ -8,7 +8,7 @@ from app.logger import get_logger
 
 logger = get_logger(__name__)
 
-REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=8.0)
+REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=4.0)
 _NOT_FOUND = object()
 
 


### PR DESCRIPTION
## Summary

- Diversify dataset generation for AI Search synthetic questions.
- Fix concurrent miner testing dispatch in query scheduler.
- Add Twitter-only synthetic tool coverage and make web and Twitter relevance checks apply only to their requested tool types.
- Include quoted tweet content in Twitter relevance scoring.
- Refactor duplicate result handling into the shared penalty model.
- Adjust advanced scraper validation weights for summary and web relevance.
- Tune superlinear formula exponents to make quality differences more meaningful in reward allocation.
- Refactor scoring values into shared constants.

**No protocol changes are made**