### PR TITLE
Upgrade bittensor to 10.3.0

### DIFF
--- a/desearch/__init__.py
+++ b/desearch/__init__.py
@@ -19,7 +19,7 @@
 
 
 # version must stay on line 22
-__version__ = "0.0.223"
+__version__ = "0.0.224"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-bittensor==10.2.0
+bittensor==10.3.0
 bittensor-wallet==4.0.1
-async-substrate-interface==1.6.3
+async-substrate-interface==2.0.2
 numpy==2.2.6
 wandb==0.23.1
-aiohttp==3.10.2
+aiohttp>=3.13.4
 apify-client==1.6.1
 openai==2.33.0
 pytz==2024.2


### PR DESCRIPTION
Fixes subtensor error: `Invalid type for data: 22 of type <class 'int'>, type_def: Composite(TypeDefComposite { fields: [Field { name: None, ty: UntrackedSymbol { id: 42, marker: PhantomData<fn() -> core::any::TypeId> }, type_name: Some("u16"), docs: [] }] })`