### PR TITLE
Fix: cyscale, scalecodec and autoupdate script

### DIFF
--- a/desearch/__init__.py
+++ b/desearch/__init__.py
@@ -19,7 +19,7 @@
 
 
 # version must stay on line 22
-__version__ = "0.0.224"
+__version__ = "0.0.225"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/desearch/bittensor/wallet.py
+++ b/desearch/bittensor/wallet.py
@@ -1,5 +1,5 @@
 import bittensor as bt
-from substrateinterface import Keypair
+from bittensor_wallet import Keypair
 
 MOCK_WALLET_KEY = "5EsrMfo7UcPs6AqAotU47VmYGfLHntS9JzhEwbY2EJMcWQxQ"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 bittensor==10.3.0
 bittensor-wallet==4.0.1
 async-substrate-interface==2.0.2
+cyscale==0.3.1
 numpy==2.2.6
 wandb==0.23.1
 aiohttp>=3.13.4
@@ -9,7 +10,6 @@ openai==2.33.0
 pytz==2024.2
 faker==40.15.0
 tiktoken==0.12.0
-substrate-interface==1.7.11
 redis[hiredis]==5.2.1
 jsonpickle==4.0.2
 aiosqlite>=0.20.0

--- a/run.sh
+++ b/run.sh
@@ -326,6 +326,8 @@ if [ "$?" -eq 1 ]; then
                         echo "New version published. Updating the local copy."
 
                         # Install latest changes just in case.
+                        # scalecodec shadows cyscale's codec shim and breaks weight setting on bittensor 10.3.0.
+                        pip uninstall async-substrate-interface substrate-interface scalecodec cyscale -y
                         pip install -e .
 
                         # Restart PM2 processes


### PR DESCRIPTION
Fixes this error on validators after upgrading to bittensor 10.3.0:

`Invalid type for data: 22 of type <class 'int'>, type_def: Composite(...)`

It happens because the old substrate-interface package installs scalecodec, which conflicts with cyscale (the codec bittensor 10.3.0 uses).

Changes:
- Removed substrate-interface, added cyscale==0.3.1 in requirements.txt
- run.sh now cleans up the conflicting packages before pip install -e .

Manual fix if you're already hitting the error:

```
pip uninstall async-substrate-interface substrate-interface scalecodec cyscale -y
pip install -e .
```