### PR TITLE
chore: Company OS impact check and releases

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,44 @@
+## What and why
+
+<!-- Normal description for reviewers. -->
+
+## Impact
+
+<!--
+Fill the block below. It is the only place "what does a customer notice, and
+why did we do this" is ever cheap and accurate, because you know it right now
+and a diff cannot answer it later.
+
+`significant: false` is a complete answer and needs nothing else. Use it for
+internal renames, behaviour-preserving refactors, formatting, editorial doc
+edits, tests, dependency bumps, build changes, and internal logging.
+
+Use `significant: true` when someone outside the team could notice without
+reading the code: a new or removed endpoint, field, screen or permission; a
+changed request or response shape; the same call returning something different;
+changed limits, quotas, timeouts or price; accuracy or latency changed enough to
+alter a published claim; changed supported regions, integrations or client
+versions; changed authentication, retention or what data is collected.
+
+It is not a size test. A one-line rate-limit change counts. A thousand-line
+refactor that preserves every behaviour does not.
+-->
+
+<!-- company-os:impact -->
+```yaml
+significant: false
+```
+
+<!-- When significant, use this shape instead:
+
+<!-- company-os:impact -->
+```yaml
+significant: true
+category: surface-added   # surface-added | surface-removed | shape-changed | behaviour-changed | limits-changed | quality-changed | availability-changed | security-or-privacy-changed
+user_impact: >-
+  What a customer can now do, or can no longer do, in their words.
+why: >-
+  The problem this removes. Not the code.
+evidence: https://...     # docs, changelog, or a screenshot
+```
+-->

--- a/.github/workflows/company-os.yml
+++ b/.github/workflows/company-os.yml
@@ -1,0 +1,33 @@
+name: Company OS
+
+# Copy this file into a product repository. It is the whole integration.
+#
+# Two things happen here, and neither needs editing again — the checks, the
+# vocabulary, the release strategy and the mapping from this repository to its
+# project all live in Company OS:
+#
+#   impact   every pull request must say whether a customer can notice it.
+#            `significant: false` is one line and passes.
+#   release  conventional commits accumulate into a Release pull request;
+#            merging it tags and publishes a GitHub Release.
+#
+# Uses the organization secret COMPANY_OS_TOKEN. Nothing to configure per repo.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, closed]
+  push:
+    branches: [main]
+
+jobs:
+  impact:
+    if: github.event_name == 'pull_request'
+    uses: Desearch-ai/company-os/.github/workflows/pr-impact.yml@main
+    secrets: inherit
+
+  release:
+    if: github.event_name == 'push'
+    uses: Desearch-ai/company-os/.github/workflows/release.yml@main
+    with:
+      release_type: simple
+    secrets: inherit


### PR DESCRIPTION
Connects this repository to Company OS. Same two files piloted on `desearch-public-api` (#404, merged), where the whole chain was verified: a PR with no impact declaration fails with an explanatory comment, `significant: false` passes, and merging opened Release PR #405.

**Impact** — every PR description needs one block saying whether a customer can notice the change. `significant: false` is one line and passes; use it for refactors, formatting, tests, dependency bumps, docs and internal renames. When it *is* customer-visible, the declaration is recorded in Company OS on merge and handed to content, social and sales with a response window.

**Releases** — this repository has no tags today, so nothing downstream can tell that something shipped. Pushes to the default branch now maintain one **Release** PR built from the conventional commits already written here; merging it creates the tag and the GitHub Release. Nothing releases without that merge.

`release_type: simple` maintains `version.txt` and `CHANGELOG.md` and touches no language manifest, so it cannot break the build. Say the word if this repository should use its real packaging type.

No secret to add — `COMPANY_OS_TOKEN` is an organization secret.

## Impact

<!-- company-os:impact -->
```yaml
significant: false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)