### PR TITLE
News-only question pool, reworded questions, and a scoring log fix

### DIFF
--- a/desearch/dataset/hf_dataset.py
+++ b/desearch/dataset/hf_dataset.py
@@ -1,4 +1,3 @@
-import hashlib
 import json
 import os
 import random
@@ -21,21 +20,6 @@ REFRESH_SECONDS = 4 * 60 * 60
 
 REQUIRED_FIELDS = ("id", "question")
 
-DATASET_LIMIT = 5000
-
-DATASETS = (
-    {
-        "repo": "sentence-transformers/squad",
-        "question_col": "question",
-        "lane": "squad",
-    },
-    {
-        "repo": "sentence-transformers/natural-questions",
-        "question_col": "query",
-        "lane": "nq",
-    },
-)
-
 
 class HFQuestionPool:
     def __init__(
@@ -44,15 +28,11 @@ class HFQuestionPool:
         cache_dir: str = CACHE_DIR,
         local_dir: Optional[str] = None,
         refresh_seconds: int = REFRESH_SECONDS,
-        datasets=DATASETS,
-        limit: int = DATASET_LIMIT,
     ):
         self.repo_id = repo_id
         self.cache_dir = Path(cache_dir)
         self.local_dir = Path(local_dir) if local_dir else None
         self.refresh_seconds = refresh_seconds
-        self.datasets = datasets
-        self.limit = limit
 
         self._rows: List[dict] = []
         self._loaded_at: float = 0.0
@@ -119,8 +99,7 @@ class HFQuestionPool:
         if not paths:
             paths = sorted(self.cache_dir.rglob("*.jsonl"))
 
-        rows = self._parse_files(paths) + self._load_datasets()
-        return self._dedup_by_id(rows)
+        return self._dedup_by_id(self._parse_files(paths))
 
     def sample_lane(self, lane: str, n: int) -> Optional[List[dict]]:
         rows = self._ensure_rows()
@@ -195,51 +174,3 @@ class HFQuestionPool:
                     rows.append(row)
 
         return rows
-
-    def _load_datasets(self) -> List[dict]:
-        rows: List[dict] = []
-        for cfg in self.datasets:
-            try:
-                rows += self._load_dataset(cfg)
-            except Exception as e:
-                bt.logging.error(f"[HFQuestionPool] Failed dataset {cfg['repo']}: {e}")
-        return rows
-
-    def _load_dataset(self, cfg: dict) -> List[dict]:
-        from datasets import load_dataset
-
-        ds = load_dataset(cfg["repo"], split="train")
-        questions = ds[cfg["question_col"]]
-        n = len(questions)
-        lane = cfg["lane"]
-
-        stride = max(1, n // self.limit)
-        start = int(time.time() // self.refresh_seconds) % stride
-
-        out: List[dict] = []
-        seen: set[str] = set()
-        for question in questions[start::stride]:
-            question = (question or "").strip()
-            if not question:
-                continue
-            qid = "h" + hashlib.sha1(question.encode("utf-8")).hexdigest()[:15]
-            if qid in seen:
-                continue
-            seen.add(qid)
-            out.append(
-                {
-                    "id": qid,
-                    "question": question,
-                    "start_date": None,
-                    "end_date": None,
-                    "lane": lane,
-                }
-            )
-            if len(out) >= self.limit:
-                break
-
-        bt.logging.info(
-            f"[HFQuestionPool] Loaded {len(out)} {lane} questions "
-            f"from {cfg['repo']} (n={n}, stride={stride}, start={start})"
-        )
-        return out

--- a/desearch/dataset/test_hf_dataset.py
+++ b/desearch/dataset/test_hf_dataset.py
@@ -41,7 +41,6 @@ def _make_pool(tmp_path):
 
     pool = HFQuestionPool(cache_dir=str(cache))
     pool._sync_from_hf = lambda: [x_file, news_file]
-    pool._load_datasets = lambda: []
     return pool
 
 

--- a/neurons/validators/clients/miner_response_logger.py
+++ b/neurons/validators/clients/miner_response_logger.py
@@ -13,6 +13,9 @@ REWARD_COMPONENT_NAMES = {
     "x_search": ["twitter", "performance"],
 }
 _RESPONSE_PAYLOAD_EXCLUDED_KEYS = {"html_content", "html_text"}
+CHUNK_SIZE = 50
+
+_pending_log_tasks: set[asyncio.Task] = set()
 
 
 def to_jsonable(value: Any) -> Any:
@@ -287,16 +290,23 @@ async def submit_logs(owner, logs: list[dict[str, Any]]) -> None:
         bt.logging.warning("Utility API client is not configured; skipping logs save.")
         return
 
-    try:
-        bt.logging.debug(f"Saving miner response logs count={len(logs)}")
-        await utility_api.save_logs(logs)
-        bt.logging.debug(f"Saved miner response logs count={len(logs)}")
-    except Exception as exc:
-        bt.logging.error(f"Failed to save miner response logs count={len(logs)}: {exc}")
+    for start in range(0, len(logs), CHUNK_SIZE):
+        chunk = logs[start : start + CHUNK_SIZE]
+
+        try:
+            bt.logging.debug(f"Saving miner response logs count={len(chunk)}")
+            await utility_api.save_logs(chunk)
+            bt.logging.debug(f"Saved miner response logs count={len(chunk)}")
+        except Exception as exc:
+            bt.logging.error(
+                f"Failed to save miner response logs count={len(chunk)}: {exc}"
+            )
 
 
 def submit_logs_best_effort(owner, logs: list[dict[str, Any]]) -> None:
     if not logs:
         return
 
-    asyncio.create_task(submit_logs(owner, logs))
+    task = asyncio.create_task(submit_logs(owner, logs))
+    _pending_log_tasks.add(task)
+    task.add_done_callback(_pending_log_tasks.discard)

--- a/neurons/validators/penalty/penalty.py
+++ b/neurons/validators/penalty/penalty.py
@@ -113,3 +113,4 @@ class PenaltyModelType(Enum):
     sort_order_penalty = "sort_order_penalty"
     min_realistic_time_penalty = "min_realistic_time_penalty"
     domain_filter_penalty = "domain_filter_penalty"
+    source_provenance_penalty = "source_provenance_penalty"

--- a/neurons/validators/penalty/source_provenance_penalty.py
+++ b/neurons/validators/penalty/source_provenance_penalty.py
@@ -1,0 +1,50 @@
+"""Zero a response whose every source is one the miner could have served itself."""
+
+import asyncio
+from typing import List
+
+import numpy as np
+
+from desearch.protocol import ScraperStreamingSynapse
+from neurons.validators.base_validator import AbstractNeuron
+from neurons.validators.penalty.penalty import BasePenaltyModel, PenaltyModelType
+from neurons.validators.utils.source_provenance import miner_ip_of, rejected_links
+
+MAX_PENALTY = 1.0
+
+
+class SourceProvenancePenaltyModel(BasePenaltyModel):
+    def __init__(self, max_penalty: float = MAX_PENALTY, neuron: AbstractNeuron = None):
+        super().__init__(max_penalty, neuron)
+
+    @property
+    def name(self) -> str:
+        return PenaltyModelType.source_provenance_penalty.value
+
+    @staticmethod
+    def _links(response: ScraperStreamingSynapse) -> List[str]:
+        try:
+            links, _ = response.get_links_from_search_results()
+            return [link for link in links if link]
+        except Exception:
+            return []
+
+    async def _penalty_for(self, response) -> float:
+        links = self._links(response)
+        if not links:
+            return 0.0
+
+        rejected = await rejected_links(links, miner_ip_of(response))
+
+        return self.max_penalty if len(rejected) == len(set(links)) else 0.0
+
+    async def calculate_penalties(
+        self,
+        responses: List[ScraperStreamingSynapse],
+        additional_params=None,
+    ) -> np.ndarray:
+        penalties = await asyncio.gather(
+            *[self._penalty_for(response) for response in responses]
+        )
+
+        return np.array(penalties, dtype=np.float32)

--- a/neurons/validators/reward/search_content_relevance.py
+++ b/neurons/validators/reward/search_content_relevance.py
@@ -18,6 +18,10 @@ from neurons.validators.utils.response_checks import (
     parse_tweet_date,
     tweet_date_in_range,
 )
+from neurons.validators.utils.source_provenance import (
+    miner_ip_of,
+    rejected_links,
+)
 from neurons.validators.utils.source_bodies import (
     cited_urls_normalized,
     highlights_in_order,
@@ -123,6 +127,19 @@ class WebSearchContentRelevanceModel(BaseRewardModel):
             }
         return meta
 
+    @staticmethod
+    async def _drop_rejected_sources(response, links_per_tool_group):
+        """Links the miner could have served itself never reach the sample."""
+        flat = [link for group in links_per_tool_group.values() for link in group]
+        rejected = await rejected_links(flat, miner_ip_of(response))
+        if not rejected:
+            return links_per_tool_group
+
+        return {
+            tool: [link for link in group if link not in rejected]
+            for tool, group in links_per_tool_group.items()
+        }
+
     def _sample_cited_and_other(self, response, links_per_tool_group):
         summary = response.texts.get(ScraperTextRole.FINAL_SUMMARY.value, "")
         cited_norm = cited_urls_normalized(summary)
@@ -154,6 +171,9 @@ class WebSearchContentRelevanceModel(BaseRewardModel):
                 continue
 
             _, links_per_tool_group = response.get_links_from_search_results()
+            links_per_tool_group = await self._drop_rejected_sources(
+                response, links_per_tool_group
+            )
             links, cited_norm = self._sample_cited_and_other(
                 response, links_per_tool_group
             )

--- a/neurons/validators/scoring/question_rewriter.py
+++ b/neurons/validators/scoring/question_rewriter.py
@@ -1,0 +1,76 @@
+"""Reword pool questions so the published wording is not the asked wording."""
+
+import asyncio
+
+import bittensor as bt
+
+from desearch.protocol import ScoringModel
+from desearch.utils import call_scoring_llm
+
+MAX_CONCURRENT = 20
+MAX_LENGTH_RATIO = 2.0
+MIN_LENGTH_RATIO = 0.5
+
+REWRITE_PROMPT = """Rewrite the search question so it asks for exactly the same thing in different words.
+
+Rules:
+- Keep every named entity, number, date and qualifier exactly as written.
+- Do not add, drop or loosen any condition.
+- Change the sentence structure and word choice, not just capitalisation or punctuation.
+- Keep it about the same length and as plainly worded as the original.
+- Do not answer the question, explain, or add commentary.
+
+Reply with the rewritten question and nothing else."""
+
+
+def _is_usable(original: str, rewritten: str) -> bool:
+    if not rewritten:
+        return False
+    ratio = len(rewritten) / max(len(original), 1)
+    return MIN_LENGTH_RATIO <= ratio <= MAX_LENGTH_RATIO
+
+
+def _clean(text: str) -> str:
+    return (text or "").strip().strip('"').strip()
+
+
+async def rewrite_question(question: str, model: ScoringModel) -> str:
+    """Reword a question, falling back to the original."""
+    try:
+        response = await call_scoring_llm(
+            [
+                {"role": "system", "content": REWRITE_PROMPT},
+                {"role": "user", "content": question},
+            ],
+            model=model,
+            temperature=1.0,
+        )
+    except Exception as e:
+        bt.logging.warning(f"[Rewriter] Rewrite failed: {e}")
+        return question
+
+    rewritten = _clean(response)
+
+    return rewritten if _is_usable(question, rewritten) else question
+
+
+async def rewrite_questions(
+    questions: list[str], model: ScoringModel
+) -> dict[str, str]:
+    """Map each distinct question to its rewrite."""
+    distinct = list(dict.fromkeys(q for q in questions if q))
+    if not distinct:
+        return {}
+
+    semaphore = asyncio.Semaphore(MAX_CONCURRENT)
+
+    async def one(question: str) -> str:
+        async with semaphore:
+            return await rewrite_question(question, model)
+
+    mapping = dict(zip(distinct, await asyncio.gather(*[one(q) for q in distinct])))
+
+    changed = sum(1 for q, r in mapping.items() if q != r)
+    bt.logging.info(f"[Rewriter] Rewrote {changed}/{len(distinct)} questions")
+
+    return mapping

--- a/neurons/validators/scoring/synthetic_query_generator.py
+++ b/neurons/validators/scoring/synthetic_query_generator.py
@@ -14,6 +14,7 @@ from desearch.utils import (
     SearchMode,
     get_mode_serving_budget,
 )
+from neurons.validators.scoring.question_rewriter import rewrite_questions
 
 WEB_TOOL = "Web Search"
 TWITTER_TOOL = "Twitter Search"
@@ -118,6 +119,7 @@ class SyntheticQueryGenerator:
             self._generate_dataset_queries, available_uids, verified_by_type
         )
         if items is not None:
+            await self._rewrite_dataset_questions(items, scoring_model)
             return items
         bt.logging.warning(
             "[SyntheticGen] Dataset pool unavailable, falling back to LLM path"
@@ -199,6 +201,21 @@ class SyntheticQueryGenerator:
             f"({instant} instant, {len(items) - instant} LLM)"
         )
         return items
+
+    @staticmethod
+    async def _rewrite_dataset_questions(
+        items: List[dict], scoring_model: ScoringModel
+    ) -> None:
+        """Reword in place, one rewrite per row so every uid gets the same text."""
+        ai_queries = [
+            item["query"] for item in items if item["search_type"] == "ai_search"
+        ]
+        rewritten = await rewrite_questions(
+            [query["query"] for query in ai_queries], scoring_model
+        )
+
+        for query in ai_queries:
+            query["query"] = rewritten.get(query["query"], query["query"])
 
     def _generate_dataset_queries(
         self,

--- a/neurons/validators/scoring/synthetic_query_generator.py
+++ b/neurons/validators/scoring/synthetic_query_generator.py
@@ -21,7 +21,7 @@ TWITTER_TOOL = "Twitter Search"
 SEARCH_TYPES = ["ai_search", "x_search"]
 
 X_LANE = "x"
-WEB_LANES = ("news", "squad", "nq")
+WEB_LANE = "news"
 
 
 random_result_types = list(
@@ -264,13 +264,7 @@ class SyntheticQueryGenerator:
         return items
 
     def _sample_web(self, n: int) -> List[dict]:
-        rows: List[dict] = []
-        for lane in WEB_LANES:
-            lane_rows = self.hf_pool.sample_lane(lane, n)
-            if lane_rows:
-                rows.extend(lane_rows)
-        random.shuffle(rows)
-        return rows[:n] if n else rows
+        return self.hf_pool.sample_lane(WEB_LANE, n) or []
 
     def _pick_ai_row(
         self,

--- a/neurons/validators/scrapers/advanced_scraper_validator.py
+++ b/neurons/validators/scrapers/advanced_scraper_validator.py
@@ -26,6 +26,9 @@ from neurons.validators.clients.miner_response_logger import (
 from neurons.validators.penalty.count_penalty import CountPenaltyModel, TWITTER_TOOL
 from neurons.validators.penalty.date_range_penalty import DateRangePenaltyModel
 from neurons.validators.penalty.domain_filter_penalty import DomainFilterPenaltyModel
+from neurons.validators.penalty.source_provenance_penalty import (
+    SourceProvenancePenaltyModel,
+)
 from neurons.validators.penalty.duplicate_results_penalty import (
     DuplicateResultsPenaltyModel,
 )
@@ -95,6 +98,7 @@ class AdvancedScraperValidator(BaseScraperValidator):
             ResultSchemaPenaltyModel(max_penalty=1, neuron=neuron),
             DateRangePenaltyModel(max_penalty=1, neuron=neuron),
             DomainFilterPenaltyModel(max_penalty=1, neuron=neuron),
+            SourceProvenancePenaltyModel(max_penalty=1, neuron=neuron),
         ]
 
         super().__init__(

--- a/neurons/validators/utils/source_provenance.py
+++ b/neurons/validators/utils/source_provenance.py
@@ -1,0 +1,214 @@
+"""Reject sources a miner could have served itself."""
+
+import asyncio
+import ipaddress
+import re
+from typing import Iterable, Optional
+from urllib.parse import urlparse
+
+import bittensor as bt
+
+WILDCARD_DNS_SUFFIXES = (
+    "sslip.io",
+    "nip.io",
+    "xip.io",
+    "traefik.me",
+    "localtest.me",
+    "lvh.me",
+    "vcap.me",
+    "1u.ms",
+)
+
+TUNNEL_SUFFIXES = (
+    "ngrok.io",
+    "ngrok.app",
+    "ngrok.dev",
+    "ngrok-free.app",
+    "trycloudflare.com",
+    "localhost.run",
+    "lhr.life",
+    "serveo.net",
+    "loca.lt",
+    "pagekite.me",
+    "telebit.io",
+    "tunnelto.dev",
+    "bore.pub",
+    "zrok.io",
+    "jprq.io",
+    "expose.sh",
+)
+
+PLATFORM_SUFFIXES = (
+    "vercel.app",
+    "netlify.app",
+    "netlify.com",
+    "herokuapp.com",
+    "pages.dev",
+    "workers.dev",
+    "r2.dev",
+    "github.io",
+    "gitlab.io",
+    "surge.sh",
+    "fly.dev",
+    "onrender.com",
+    "railway.app",
+    "koyeb.app",
+    "glitch.me",
+    "repl.co",
+    "replit.app",
+    "deno.dev",
+    "val.run",
+    "cyclic.app",
+    "azurewebsites.net",
+    "appspot.com",
+    "firebaseapp.com",
+    "web.app",
+    "s3.amazonaws.com",
+    "s3-website.amazonaws.com",
+    "storage.googleapis.com",
+    "blob.core.windows.net",
+    "digitaloceanspaces.com",
+    "ondigitalocean.app",
+)
+
+SHORTENER_HOSTS = frozenset(
+    {
+        "bit.ly",
+        "tinyurl.com",
+        "t.co",
+        "goo.gl",
+        "ow.ly",
+        "buff.ly",
+        "is.gd",
+        "rb.gy",
+        "cutt.ly",
+        "shorturl.at",
+        "rebrand.ly",
+        "s.id",
+        "tiny.cc",
+        "shorte.st",
+        "t.ly",
+    }
+)
+
+PRIVATE_TLDS = (
+    ".local",
+    ".internal",
+    ".test",
+    ".localhost",
+    ".onion",
+    ".i2p",
+    ".invalid",
+)
+
+DNS_TIMEOUT_SECONDS = 2.0
+
+_EMBEDDED_IP = re.compile(
+    r"(?:^|[.-])(\d{1,3})[-.](\d{1,3})[-.](\d{1,3})[-.](\d{1,3})(?:[.-]|$)"
+)
+_ALL_DIGITS = re.compile(r"^\d+$")
+_HEX_HOST = re.compile(r"^0x[0-9a-f]+$")
+
+_resolved: dict[str, Optional[str]] = {}
+
+
+def host_of(url: str) -> str:
+    try:
+        return (urlparse(url or "").hostname or "").lower()
+    except ValueError:
+        return ""
+
+
+def _embedded_ip(host: str) -> Optional[str]:
+    match = _EMBEDDED_IP.search(host)
+    if not match:
+        return None
+    try:
+        return str(ipaddress.IPv4Address(".".join(match.groups())))
+    except ValueError:
+        return None
+
+
+def _is_ip_literal(host: str) -> bool:
+    """Dotted, IPv6, and the decimal/hex spellings a browser also accepts."""
+    if _ALL_DIGITS.match(host) or _HEX_HOST.match(host):
+        return True
+    try:
+        ipaddress.ip_address(host)
+        return True
+    except ValueError:
+        return False
+
+
+def _matches(host: str, suffixes: Iterable[str]) -> bool:
+    return any(host == suffix or host.endswith(f".{suffix}") for suffix in suffixes)
+
+
+async def resolve(host: str) -> Optional[str]:
+    """First A record for the host, or None; failures resolve to None."""
+    if host in _resolved:
+        return _resolved[host]
+
+    try:
+        infos = await asyncio.wait_for(
+            asyncio.get_running_loop().getaddrinfo(host, None, family=2, type=1),
+            timeout=DNS_TIMEOUT_SECONDS,
+        )
+        address = infos[0][4][0] if infos else None
+    except Exception:
+        address = None
+
+    _resolved[host] = address
+
+    return address
+
+
+async def rejection_reason(url: str, miner_ip: Optional[str] = None) -> Optional[str]:
+    if (url or "").strip().lower().startswith("http://"):
+        return "http"
+
+    host = host_of(url)
+    if not host:
+        return "no-host"
+    if _is_ip_literal(host):
+        return "ip-host"
+    if "." not in host or host.endswith(PRIVATE_TLDS):
+        return "not-public"
+    if _matches(host, WILDCARD_DNS_SUFFIXES) or _matches(host, TUNNEL_SUFFIXES):
+        return "wildcard-dns"
+    if _matches(host, PLATFORM_SUFFIXES):
+        return "hosting-platform"
+    if host in SHORTENER_HOSTS:
+        return "url-shortener"
+
+    embedded = _embedded_ip(host)
+    if embedded:
+        return "self-host" if embedded == miner_ip else "ip-host"
+
+    if miner_ip and await resolve(host) == miner_ip:
+        return "self-host"
+
+    return None
+
+
+async def rejected_links(
+    links: Iterable[str], miner_ip: Optional[str] = None
+) -> dict[str, str]:
+    """Map each unusable link to why it cannot be treated as a source."""
+    unique = list(dict.fromkeys(link for link in links if link))
+    reasons = await asyncio.gather(
+        *[rejection_reason(link, miner_ip) for link in unique]
+    )
+    rejected = {link: reason for link, reason in zip(unique, reasons) if reason}
+
+    if rejected:
+        bt.logging.debug(
+            f"[Provenance] rejected {len(rejected)}/{len(unique)} sources: "
+            f"{sorted(set(rejected.values()))}"
+        )
+
+    return rejected
+
+
+def miner_ip_of(response) -> Optional[str]:
+    return getattr(getattr(response, "axon", None), "ip", None)

--- a/tests/validators/test_dataset_lane_routing.py
+++ b/tests/validators/test_dataset_lane_routing.py
@@ -33,26 +33,6 @@ WEB_ROWS = {
         }
         for i in range(5)
     ],
-    "squad": [
-        {
-            "id": f"s{i}",
-            "question": f"squad lane question {i}",
-            "start_date": None,
-            "end_date": None,
-            "lane": "squad",
-        }
-        for i in range(5)
-    ],
-    "nq": [
-        {
-            "id": f"q{i}",
-            "question": f"nq lane question {i}",
-            "start_date": None,
-            "end_date": None,
-            "lane": "nq",
-        }
-        for i in range(5)
-    ],
 }
 
 X_QUESTIONS = {r["question"] for r in X_ROWS}
@@ -139,7 +119,7 @@ def test_x_fallback_when_no_x_lane():
 
 
 def test_returns_none_when_pool_empty():
-    pool = FakePool(x_rows=[], web_rows={"news": [], "squad": [], "nq": []})
+    pool = FakePool(x_rows=[], web_rows={"news": []})
     gen = _make_gen(pool)
 
     assert gen._generate_dataset_queries([1, 2], {}) is None

--- a/tests/validators/test_miner_response_logging.py
+++ b/tests/validators/test_miner_response_logging.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from neurons.validators.clients.miner_response_logger import (
+    CHUNK_SIZE,
     build_log_entry,
     build_reward_payload,
     submit_logs,
@@ -314,3 +315,26 @@ async def test_x_posts_by_urls_logs_organic():
     assert results == [{"id": "abc"}]
     assert build_log_entry.call_args.kwargs["miner_uid"] == 99
     submit_logs_best_effort.assert_called_once_with(validator.neuron, [{"ok": True}])
+
+
+@pytest.mark.asyncio
+async def test_submit_logs_sends_one_request_per_chunk():
+    owner = _fake_owner()
+    logs = [{"i": index} for index in range(CHUNK_SIZE + 1)]
+
+    await submit_logs(owner, logs)
+
+    assert [
+        len(call.args[0]) for call in owner.utility_api.save_logs.await_args_list
+    ] == [CHUNK_SIZE, 1]
+
+
+@pytest.mark.asyncio
+async def test_submit_logs_continues_after_a_failed_chunk():
+    owner = _fake_owner()
+    logs = [{"i": index} for index in range(CHUNK_SIZE + 1)]
+    owner.utility_api.save_logs.side_effect = [RuntimeError("boom"), {"inserted": 1}]
+
+    await submit_logs(owner, logs)
+
+    assert owner.utility_api.save_logs.await_count == 2

--- a/tests/validators/test_question_rewriter.py
+++ b/tests/validators/test_question_rewriter.py
@@ -1,0 +1,80 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from desearch.protocol import ScoringModel
+from neurons.validators.scoring.question_rewriter import (
+    rewrite_question,
+    rewrite_questions,
+)
+from neurons.validators.scoring.synthetic_query_generator import SyntheticQueryGenerator
+
+MODEL = ScoringModel.OPENAI_GPT4_1_NANO
+QUESTION = "Which Indian regulatory body issued show-cause notices in August 2026?"
+
+
+def _llm(*responses):
+    return patch(
+        "neurons.validators.scoring.question_rewriter.call_scoring_llm",
+        AsyncMock(side_effect=list(responses)),
+    )
+
+
+@pytest.mark.asyncio
+async def test_rewrite_replaces_the_question():
+    reworded = "In August 2026, which regulatory body in India sent show-cause notices?"
+
+    with _llm(f'"{reworded}"  '):
+        assert await rewrite_question(QUESTION, MODEL) == reworded
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("response", ["", "   ", "why?", "x" * 500, None])
+async def test_unusable_rewrite_keeps_the_original(response):
+    with _llm(response):
+        assert await rewrite_question(QUESTION, MODEL) == QUESTION
+
+
+@pytest.mark.asyncio
+async def test_llm_failure_keeps_the_original():
+    with _llm(RuntimeError("boom")):
+        assert await rewrite_question(QUESTION, MODEL) == QUESTION
+
+
+@pytest.mark.asyncio
+async def test_each_distinct_question_is_rewritten_once():
+    with _llm(
+        "Which body in India sent show-cause notices during August 2026?",
+        "About what did the second question actually inquire?",
+    ) as llm:
+        mapping = await rewrite_questions(
+            [QUESTION, QUESTION, "What did the second question actually ask about?"],
+            MODEL,
+        )
+
+    assert llm.await_count == 2
+    assert (
+        mapping[QUESTION]
+        == "Which body in India sent show-cause notices during August 2026?"
+    )
+    assert (
+        mapping["What did the second question actually ask about?"]
+        == "About what did the second question actually inquire?"
+    )
+
+
+@pytest.mark.asyncio
+async def test_same_row_asked_to_many_uids_gets_one_rewrite():
+    items = [
+        {"uid": 1, "search_type": "ai_search", "query": {"query": QUESTION}},
+        {"uid": 2, "search_type": "ai_search", "query": {"query": QUESTION}},
+        {"uid": 3, "search_type": "x_search", "query": {"query": "x lane question"}},
+    ]
+
+    with _llm("a differently worded question about notices"):
+        await SyntheticQueryGenerator._rewrite_dataset_questions(items, MODEL)
+
+    assert {i["query"]["query"] for i in items if i["search_type"] == "ai_search"} == {
+        "a differently worded question about notices"
+    }
+    assert items[2]["query"]["query"] == "x lane question"


### PR DESCRIPTION
## Summary

Three changes to the validator:

1. **Static question sets removed.** Web questions came in equal parts from our news pool and two public static datasets (SQuAD and Natural Questions). Those two never change, so answers can be prepared ahead of time and served instantly. All web questions now come from the news pool, so they are always current and dated with no fixed list to prepare for.

2. **Questions are reworded before they are asked.** The pool is published publicly, so its exact wording can be matched against prepared answers. Each question is now reworded once per scoring round, keeping the same meaning and date window. Every miner asked it gets identical wording, and if rewording fails the original is used.

3. **Scoring logs are saved again.** A full scoring round (over 1,300 entries) went out in one request. On larger validators that exceeded the upload limit, so the whole round was lost. Logs now go in batches of 50, and one failing batch no longer takes the rest with it.

**Validators need to update to restore scoring log delivery.**